### PR TITLE
fix: Add route handler for Home Assistant Ingress double-slash path i…

### DIFF
--- a/printernizer/CHANGELOG.md
+++ b/printernizer/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Printernizer Home Assistant Add-on will be documented in this file.
 
+## [2.0.10] - 2025-10-24
+
+### Fixed
+- **Critical Ingress routing fix**: Added route handler for double-slash (`//`) path
+- Fixed 404 error when accessing add-on via Home Assistant Ingress
+- Home Assistant Ingress was forwarding requests to `//` instead of `/`
+
+### Technical Details
+- Added `@app.get("//")` route handler to serve frontend for double-slash requests
+- This is a known Home Assistant Ingress behavior where trailing slashes in ingress paths result in double slashes
+- No changes to application functionality - routing fix only
+
 ## [2.0.9] - 2025-10-24
 
 ### Improved

--- a/printernizer/Dockerfile
+++ b/printernizer/Dockerfile
@@ -71,7 +71,7 @@ EXPOSE 8000
 LABEL io.hass.name="Printernizer" \
       io.hass.description="Professional 3D Printer Management System" \
       io.hass.type="addon" \
-      io.hass.version="2.0.9" \
+      io.hass.version="2.0.10" \
       io.hass.arch="aarch64|amd64|armv7|armhf"
 
 # Start the add-on service

--- a/printernizer/config.yaml
+++ b/printernizer/config.yaml
@@ -1,5 +1,5 @@
 name: Printernizer
-version: "2.0.9"
+version: "2.0.10"
 slug: printernizer
 description: Professional 3D Printer Management for Bambu Lab A1 and Prusa Core One
 url: https://github.com/schmacka/printernizer

--- a/printernizer/run.sh
+++ b/printernizer/run.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Colors for output
-bashio::log.info "Starting Printernizer Home Assistant Add-on v2.0.9..."
+bashio::log.info "Starting Printernizer Home Assistant Add-on v2.0.10..."
 
 # Read configuration from Home Assistant options
 CONFIG_PATH="/data/options.json"

--- a/src/main.py
+++ b/src/main.py
@@ -389,6 +389,13 @@ def create_application() -> FastAPI:
             from fastapi.responses import FileResponse
             return FileResponse(str(frontend_path / "index.html"))
 
+        # Handle Home Assistant Ingress double-slash issue
+        # HA Ingress sometimes forwards requests as // instead of /
+        @app.get("//")
+        async def read_index_double_slash():
+            from fastapi.responses import FileResponse
+            return FileResponse(str(frontend_path / "index.html"))
+
         @app.get("/debug")
         async def read_debug():
             from fastapi.responses import FileResponse


### PR DESCRIPTION
…ssue

Home Assistant Ingress was forwarding requests to '//' instead of '/', causing a 404 error when accessing the frontend via Ingress. This is a known HA Ingress behavior where trailing slashes in the ingress path result in double slashes being forwarded to the application.

Changes:
- Added @app.get("//") route handler to serve index.html for double-slash requests
- Updated version to 2.0.10 in config.yaml, Dockerfile, and run.sh
- Updated CHANGELOG.md with fix details

Root cause analysis from logs:
- Request: "GET // HTTP/1.1" 404 Not Found
- Source IP: 172.30.32.2 (HA Ingress proxy)
- User-Agent: Home Assistant iOS app


This fix ensures the frontend loads correctly when accessed via HA Ingress.

Fixes: 404 error on Home Assistant Ingress access
Version: 2.0.9 -> 2.0.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Performance improvement

## Related Issues
Closes #(issue number)

## Changes Made
- [ ] List the specific changes made
- [ ] Include any new files created
- [ ] Mention any files deleted or renamed
- [ ] Note any configuration changes

## Printer Compatibility
- [ ] Tested with Bambu Lab A1
- [ ] Tested with Prusa Core One
- [ ] Works with both printer types
- [ ] Not applicable (non-printer specific change)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Tested in development environment
- [ ] Tested with real printers

### Test Results
Describe the testing performed:
```
Test output, screenshots, or results can go here
```

## Documentation
- [ ] Code documentation updated (docstrings, comments)
- [ ] README.md updated (if needed)
- [ ] API documentation updated (if API changes)
- [ ] User documentation updated (if user-facing changes)

## Code Quality
- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code is well-commented and understandable
- [ ] No unnecessary debug code or comments left
- [ ] Error handling appropriate for changes

## Security Considerations
- [ ] No sensitive information exposed
- [ ] Input validation added where needed
- [ ] Authentication/authorization maintained
- [ ] GDPR compliance maintained (if applicable)
- [ ] No new security vulnerabilities introduced

## German Business Compliance (if applicable)
- [ ] German language support maintained
- [ ] VAT calculations correct
- [ ] Timezone handling appropriate
- [ ] Currency formatting maintained

## Performance Impact
- [ ] No performance degradation expected
- [ ] Performance improvement included
- [ ] Database queries optimized
- [ ] Memory usage considered
- [ ] File handling efficient

## Breaking Changes
If this PR introduces breaking changes, describe:
- What changes are breaking?
- How should users migrate?
- Any configuration updates needed?

## Screenshots (if applicable)
Add screenshots for UI changes or new features.

## Additional Notes
Any additional information, concerns, or context for reviewers.

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published