### PR TITLE
fix: Correct WebSocket URL construction for Home Assistant Ingress

### DIFF
--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -26,9 +26,13 @@ const getWebSocketUrl = () => {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 
     // If accessed through HA Ingress (no port in URL) or on port 8123, use relative WebSocket path
-    // HA Ingress supports WebSocket proxying
+    // HA Ingress supports WebSocket proxying - must use relative path to get proxied correctly
     if (!port || port === '8123') {
-        return `${protocol}//${host}/ws`;
+        // Use relative WebSocket path so HA Ingress can proxy it correctly
+        // The path will be relative to the current location, including any ingress prefix
+        const basePath = window.location.pathname.split('/').slice(0, -1).join('/');
+        const wsPath = basePath ? `${basePath}/ws` : '/ws';
+        return `${protocol}//${host}${window.location.port ? ':' + window.location.port : ''}${wsPath}`;
     }
 
     // Direct access mode: use explicit port 8000


### PR DESCRIPTION
The frontend WebSocket connection was failing in HA Ingress mode because it was using an absolute URL (ws://host/ws) instead of a relative path that respects the ingress prefix.

Changes:
- Updated getWebSocketUrl() to extract the base path from current URL
- WebSocket now uses relative path including ingress prefix
- Maintains backward compatibility with direct access mode

This ensures WebSocket connections are properly proxied through HA Ingress, allowing the frontend to establish real-time connections with the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Performance improvement

## Related Issues
Closes #(issue number)

## Changes Made
- [ ] List the specific changes made
- [ ] Include any new files created
- [ ] Mention any files deleted or renamed
- [ ] Note any configuration changes

## Printer Compatibility
- [ ] Tested with Bambu Lab A1
- [ ] Tested with Prusa Core One
- [ ] Works with both printer types
- [ ] Not applicable (non-printer specific change)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Tested in development environment
- [ ] Tested with real printers

### Test Results
Describe the testing performed:
```
Test output, screenshots, or results can go here
```

## Documentation
- [ ] Code documentation updated (docstrings, comments)
- [ ] README.md updated (if needed)
- [ ] API documentation updated (if API changes)
- [ ] User documentation updated (if user-facing changes)

## Code Quality
- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code is well-commented and understandable
- [ ] No unnecessary debug code or comments left
- [ ] Error handling appropriate for changes

## Security Considerations
- [ ] No sensitive information exposed
- [ ] Input validation added where needed
- [ ] Authentication/authorization maintained
- [ ] GDPR compliance maintained (if applicable)
- [ ] No new security vulnerabilities introduced

## German Business Compliance (if applicable)
- [ ] German language support maintained
- [ ] VAT calculations correct
- [ ] Timezone handling appropriate
- [ ] Currency formatting maintained

## Performance Impact
- [ ] No performance degradation expected
- [ ] Performance improvement included
- [ ] Database queries optimized
- [ ] Memory usage considered
- [ ] File handling efficient

## Breaking Changes
If this PR introduces breaking changes, describe:
- What changes are breaking?
- How should users migrate?
- Any configuration updates needed?

## Screenshots (if applicable)
Add screenshots for UI changes or new features.

## Additional Notes
Any additional information, concerns, or context for reviewers.

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published