### PR TITLE
feat: Add configurable library folder for Home Assistant add-on

### DIFF
--- a/printernizer/DOCS.md
+++ b/printernizer/DOCS.md
@@ -69,6 +69,7 @@ The Configuration tab contains all add-on settings in YAML format.
 ```yaml
 log_level: info
 timezone: Europe/Berlin
+library_folder: /data/printernizer/library
 enable_3d_preview: true
 enable_websockets: true
 enable_business_reports: true
@@ -83,6 +84,16 @@ enable_business_reports: true
 - Sets timezone for all timestamps
 - Use IANA timezone format (e.g., `America/New_York`, `Asia/Tokyo`)
 - Affects business reports and job timestamps
+
+**library_folder** (optional, default: `/data/printernizer/library`)
+- Path where downloaded 3D model files are stored
+- Must be an absolute path
+- Automatically created if it doesn't exist
+- Examples:
+  - `/data/printernizer/library` (default)
+  - `/share/3d-models` (shared with other add-ons)
+  - `/mnt/usb-drive/library` (external storage)
+- **Note:** Ensure the path is accessible and has sufficient storage space
 
 **enable_3d_preview** (optional, default: `true`)
 - Enables automatic 3D preview generation for STL, 3MF, and G-code files
@@ -406,7 +417,10 @@ All persistent data stored in `/data/printernizer/`:
 ```
 /data/printernizer/
 ├── printernizer.db          # SQLite database (jobs, printers, settings)
-├── printer-files/           # Downloaded printer files
+├── library/                 # Downloaded 3D model files (configurable)
+│   ├── models/             # Organized 3D models
+│   └── metadata/           # File metadata and checksums
+├── printer-files/           # Temporary printer files
 │   ├── bambu-lab-a1-1/     # Organized by printer
 │   └── prusa-core-one-1/
 ├── preview-cache/           # 3D preview thumbnails
@@ -414,6 +428,8 @@ All persistent data stored in `/data/printernizer/`:
 │   └── metadata/
 └── backups/                 # Automatic database backups
 ```
+
+**Note:** The library folder location is configurable via `library_folder` setting. By default it's `/data/printernizer/library`, but you can change it to any accessible path (e.g., external storage, shared folders).
 
 ### Backup and Restore
 

--- a/printernizer/README.md
+++ b/printernizer/README.md
@@ -83,6 +83,7 @@ printers:
 |--------|------|---------|-------------|
 | `log_level` | list | `info` | Logging level: debug, info, warning, error |
 | `timezone` | string | `Europe/Berlin` | Your timezone for timestamps |
+| `library_folder` | string | `/data/printernizer/library` | Path where 3D model files are stored |
 | `enable_3d_preview` | bool | `true` | Enable 3D file preview generation |
 | `enable_websockets` | bool | `true` | Enable real-time WebSocket updates |
 | `enable_business_reports` | bool | `true` | Enable business analytics features |
@@ -188,6 +189,7 @@ All data is stored in Home Assistant's add-on data directory:
 ```
 /data/printernizer/
 ├── printernizer.db          # SQLite database
+├── library/                 # 3D model files (configurable via library_folder)
 ├── printer-files/           # Downloaded files
 ├── preview-cache/           # 3D preview thumbnails
 └── backups/                 # Database backups

--- a/printernizer/config.yaml
+++ b/printernizer/config.yaml
@@ -38,6 +38,7 @@ webui: "[PROTO:ssl]://[HOST]:[PORT:8000]"
 options:
   log_level: info
   timezone: Europe/Berlin
+  library_folder: /data/printernizer/library
   enable_3d_preview: true
   enable_websockets: true
   enable_business_reports: true
@@ -46,6 +47,7 @@ options:
 schema:
   log_level: list(debug|info|warning|error)?
   timezone: str?
+  library_folder: str?
   enable_3d_preview: bool?
   enable_websockets: bool?
   enable_business_reports: bool?

--- a/printernizer/run.sh
+++ b/printernizer/run.sh
@@ -13,6 +13,7 @@ CONFIG_PATH="/data/options.json"
 # Parse options with jq and bashio
 LOG_LEVEL=$(bashio::config 'log_level' 'info')
 TIMEZONE=$(bashio::config 'timezone' 'Europe/Berlin')
+LIBRARY_FOLDER=$(bashio::config 'library_folder' '/data/printernizer/library')
 ENABLE_3D_PREVIEW=$(bashio::config 'enable_3d_preview' 'true')
 ENABLE_WEBSOCKETS=$(bashio::config 'enable_websockets' 'true')
 ENABLE_BUSINESS_REPORTS=$(bashio::config 'enable_business_reports' 'true')
@@ -20,6 +21,7 @@ ENABLE_BUSINESS_REPORTS=$(bashio::config 'enable_business_reports' 'true')
 bashio::log.info "Configuration loaded from Home Assistant"
 bashio::log.info "  • Log Level: ${LOG_LEVEL}"
 bashio::log.info "  • Timezone: ${TIMEZONE}"
+bashio::log.info "  • Library Folder: ${LIBRARY_FOLDER}"
 bashio::log.info "  • 3D Preview: ${ENABLE_3D_PREVIEW}"
 bashio::log.info "  • WebSockets: ${ENABLE_WEBSOCKETS}"
 bashio::log.info "  • Business Reports: ${ENABLE_BUSINESS_REPORTS}"
@@ -31,6 +33,7 @@ bashio::log.info "Timezone set to ${TZ}"
 # Create necessary directories
 bashio::log.info "Setting up directories..."
 mkdir -p /data/printernizer
+mkdir -p "${LIBRARY_FOLDER}"
 mkdir -p /data/printernizer/printer-files
 mkdir -p /data/printernizer/preview-cache
 mkdir -p /data/printernizer/backups
@@ -60,6 +63,7 @@ TZ=${TIMEZONE}
 DATABASE_PATH=/data/printernizer/printernizer.db
 
 # File paths (persistent storage in /data)
+LIBRARY_PATH=${LIBRARY_FOLDER}
 UPLOAD_PATH=/data/printernizer/printer-files
 BACKUP_PATH=/data/printernizer/backups
 CACHE_PATH=/data/printernizer/preview-cache


### PR DESCRIPTION
Add library_folder configuration option to Home Assistant add-on configuration tab, allowing users to specify a custom path for storing downloaded 3D model files.

Changes:
- Add library_folder option to config.yaml (default: /data/printernizer/library)
- Update run.sh to read library_folder from HA configuration
- Set LIBRARY_PATH environment variable from configured value
- Automatically create library folder during startup
- Document library_folder option in README.md and DOCS.md
- Update data storage documentation with configurable library location

Users can now configure library storage location to:
- Use external storage (USB drives, network mounts)
- Share library with other Home Assistant add-ons
- Customize organization based on their setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Performance improvement

## Related Issues
Closes #(issue number)

## Changes Made
- [ ] List the specific changes made
- [ ] Include any new files created
- [ ] Mention any files deleted or renamed
- [ ] Note any configuration changes

## Printer Compatibility
- [ ] Tested with Bambu Lab A1
- [ ] Tested with Prusa Core One
- [ ] Works with both printer types
- [ ] Not applicable (non-printer specific change)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Tested in development environment
- [ ] Tested with real printers

### Test Results
Describe the testing performed:
```
Test output, screenshots, or results can go here
```

## Documentation
- [ ] Code documentation updated (docstrings, comments)
- [ ] README.md updated (if needed)
- [ ] API documentation updated (if API changes)
- [ ] User documentation updated (if user-facing changes)

## Code Quality
- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code is well-commented and understandable
- [ ] No unnecessary debug code or comments left
- [ ] Error handling appropriate for changes

## Security Considerations
- [ ] No sensitive information exposed
- [ ] Input validation added where needed
- [ ] Authentication/authorization maintained
- [ ] GDPR compliance maintained (if applicable)
- [ ] No new security vulnerabilities introduced

## German Business Compliance (if applicable)
- [ ] German language support maintained
- [ ] VAT calculations correct
- [ ] Timezone handling appropriate
- [ ] Currency formatting maintained

## Performance Impact
- [ ] No performance degradation expected
- [ ] Performance improvement included
- [ ] Database queries optimized
- [ ] Memory usage considered
- [ ] File handling efficient

## Breaking Changes
If this PR introduces breaking changes, describe:
- What changes are breaking?
- How should users migrate?
- Any configuration updates needed?

## Screenshots (if applicable)
Add screenshots for UI changes or new features.

## Additional Notes
Any additional information, concerns, or context for reviewers.

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published