### PR TITLE
Add server shutdown button to frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1017,6 +1017,15 @@
                                     <p>Lade System-Informationen...</p>
                                 </div>
                             </div>
+                            <div class="system-actions" style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
+                                <button class="btn btn-danger" onclick="shutdownServer()">
+                                    <span class="btn-icon">⏹️</span>
+                                    Server herunterfahren
+                                </button>
+                                <p class="text-muted" style="margin-top: 10px; font-size: 0.875rem;">
+                                    ⚠️ Der Server wird ordnungsgemäß heruntergefahren. Alle Dienste werden gestoppt.
+                                </p>
+                            </div>
                         </div>
                     </div>
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -146,6 +146,10 @@ class ApiClient {
         return this.get(CONFIG.ENDPOINTS.SYSTEM_INFO);
     }
 
+    async shutdownServer() {
+        return this.post(CONFIG.ENDPOINTS.SYSTEM_SHUTDOWN);
+    }
+
     // Settings Endpoints
     async getApplicationSettings() {
         return this.get(CONFIG.ENDPOINTS.APPLICATION_SETTINGS);

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -274,6 +274,7 @@ const CONFIG = {
         // System
         HEALTH: 'health',
         SYSTEM_INFO: '/system/info',
+        SYSTEM_SHUTDOWN: '/system/shutdown',
 
         // Settings
         APPLICATION_SETTINGS: 'settings/application',

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -455,6 +455,43 @@ async function removeWatchFolderFromSettings(folderPath) {
     }
 }
 
+async function shutdownServer() {
+    const confirmed = confirm(
+        'Sind Sie sicher, dass Sie den Server herunterfahren möchten?\n\n' +
+        'Der Server wird ordnungsgemäß heruntergefahren und alle aktiven Verbindungen werden geschlossen.'
+    );
+    if (!confirmed) return;
+
+    try {
+        showToast('warning', 'Server wird heruntergefahren', 'Bitte warten Sie...', 3000);
+
+        // Call shutdown API
+        await api.shutdownServer();
+
+        showToast('success', 'Server heruntergefahren',
+                 'Der Server wurde erfolgreich heruntergefahren.', 5000);
+
+        // Optionally disable UI or show a message that server is down
+        setTimeout(() => {
+            document.body.innerHTML = `
+                <div style="display: flex; align-items: center; justify-content: center; height: 100vh; flex-direction: column; font-family: system-ui;">
+                    <h1 style="color: #ef4444;">⏹️ Server wurde heruntergefahren</h1>
+                    <p style="color: #6b7280; margin-top: 10px;">Der Server wurde ordnungsgemäß heruntergefahren.</p>
+                    <p style="color: #6b7280;">Sie können dieses Fenster jetzt schließen.</p>
+                </div>
+            `;
+        }, 2000);
+
+    } catch (error) {
+        window.ErrorHandler?.handleSettingsError(error, { operation: 'shutdown' });
+        if (error instanceof ApiError) {
+            showToast('error', 'Fehler beim Herunterfahren', error.getUserMessage());
+        } else {
+            showToast('error', 'Fehler', 'Server konnte nicht heruntergefahren werden');
+        }
+    }
+}
+
 // Export for use in main.js
 if (typeof window !== 'undefined') {
     window.settingsManager = settingsManager;


### PR DESCRIPTION
Implemented a graceful server shutdown feature accessible from the settings page.

Backend changes:
- Added POST /api/v1/system/shutdown endpoint in system.py
- Sends SIGTERM signal to trigger graceful shutdown via existing signal handlers
- Properly logs shutdown requests

Frontend changes:
- Added shutdown button in System Information section (settings page)
- Added shutdownServer() method to API client
- Added shutdown endpoint to config
- Added shutdownServer() handler with confirmation dialog
- Displays shutdown confirmation and replaces UI with shutdown message

The shutdown process:
1. User clicks "Server herunterfahren" button and confirms
2. API sends SIGTERM to current process
3. Signal handler in main.py triggers graceful shutdown
4. Lifespan context manager stops all services properly
5. UI shows confirmation message

Addresses user request for proper backend/frontend process termination.

# Pull Request

## Summary
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Performance improvement

## Related Issues
Closes #(issue number)

## Changes Made
- [ ] List the specific changes made
- [ ] Include any new files created
- [ ] Mention any files deleted or renamed
- [ ] Note any configuration changes

## Printer Compatibility
- [ ] Tested with Bambu Lab A1
- [ ] Tested with Prusa Core One
- [ ] Works with both printer types
- [ ] Not applicable (non-printer specific change)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Tested in development environment
- [ ] Tested with real printers

### Test Results
Describe the testing performed:
```
Test output, screenshots, or results can go here
```

## Documentation
- [ ] Code documentation updated (docstrings, comments)
- [ ] README.md updated (if needed)
- [ ] API documentation updated (if API changes)
- [ ] User documentation updated (if user-facing changes)

## Code Quality
- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code is well-commented and understandable
- [ ] No unnecessary debug code or comments left
- [ ] Error handling appropriate for changes

## Security Considerations
- [ ] No sensitive information exposed
- [ ] Input validation added where needed
- [ ] Authentication/authorization maintained
- [ ] GDPR compliance maintained (if applicable)
- [ ] No new security vulnerabilities introduced

## German Business Compliance (if applicable)
- [ ] German language support maintained
- [ ] VAT calculations correct
- [ ] Timezone handling appropriate
- [ ] Currency formatting maintained

## Performance Impact
- [ ] No performance degradation expected
- [ ] Performance improvement included
- [ ] Database queries optimized
- [ ] Memory usage considered
- [ ] File handling efficient

## Breaking Changes
If this PR introduces breaking changes, describe:
- What changes are breaking?
- How should users migrate?
- Any configuration updates needed?

## Screenshots (if applicable)
Add screenshots for UI changes or new features.

## Additional Notes
Any additional information, concerns, or context for reviewers.

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published