### PR TITLE
fix: Fix printer persistence in Home Assistant addon

### DIFF
--- a/printernizer/CHANGELOG.md
+++ b/printernizer/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [2.0.45] - 2025-11-06
+
+### Fixed
+- **Critical: Printer Persistence Fix**: Printer configurations now persist across addon restarts
+  - Changed printer config storage from `/app/config/printers.json` (ephemeral) to `/data/printernizer/printers.json` (persistent)
+  - Printers added through the frontend will no longer disappear after addon restart
+  - ConfigService now automatically detects Home Assistant environment and uses persistent storage
+  - Added `PRINTER_CONFIG_PATH` environment variable in run.sh for explicit configuration
+
+### Technical Details
+- **Root Cause**: Printer configurations were saved to `/app/config/printers.json`, which is part of the container image and is recreated on each restart
+- **Solution**: Store printer configs in `/data/printernizer/` which is mapped to Home Assistant's persistent storage
+- Only `/data` directory is persistent in HA addons (configured via `map: - data:rw` in config.yaml)
+- This fix ensures all user configurations persist across container restarts
+
 ## [2.0.44] - 2025-11-06
 
 - feat: Enable startup discovery by default with 60s delay and fix pre-fill

--- a/printernizer/config.yaml
+++ b/printernizer/config.yaml
@@ -1,5 +1,5 @@
 name: Printernizer
-version: "2.0.44"
+version: "2.0.45"
 slug: printernizer
 description: Professional 3D Printer Management for Bambu Lab A1 and Prusa Core One
 url: https://github.com/schmacka/printernizer

--- a/printernizer/run.sh
+++ b/printernizer/run.sh
@@ -25,6 +25,7 @@ bashio::log.info "  • Library Folder: ${LIBRARY_FOLDER}"
 bashio::log.info "  • 3D Preview: ${ENABLE_3D_PREVIEW}"
 bashio::log.info "  • WebSockets: ${ENABLE_WEBSOCKETS}"
 bashio::log.info "  • Business Reports: ${ENABLE_BUSINESS_REPORTS}"
+bashio::log.info "  • Printer Config: /data/printernizer/printers.json (persistent)"
 
 # Set timezone
 export TZ="${TIMEZONE}"
@@ -61,6 +62,9 @@ TZ=${TIMEZONE}
 
 # Database
 DATABASE_PATH=/data/printernizer/printernizer.db
+
+# Printer configuration (persistent storage in /data)
+PRINTER_CONFIG_PATH=/data/printernizer/printers.json
 
 # File paths (persistent storage in /data)
 LIBRARY_PATH=${LIBRARY_FOLDER}

--- a/src/main.py
+++ b/src/main.py
@@ -71,7 +71,7 @@ from src.utils.timing import StartupTimer
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="1.5.9")
+APP_VERSION = get_version(fallback="2.0.45")
 
 
 # Prometheus metrics - initialized once

--- a/src/utils/version.py
+++ b/src/utils/version.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 
-def get_version(fallback: str = "1.5.18") -> str:
+def get_version(fallback: str = "2.0.45") -> str:
     """
     Get application version from git tags.
 
@@ -46,7 +46,7 @@ def get_version(fallback: str = "1.5.18") -> str:
     return fallback
 
 
-def get_short_version(fallback: str = "1.5.18") -> str:
+def get_short_version(fallback: str = "2.0.45") -> str:
     """
     Get short version (major.minor.patch only).
 


### PR DESCRIPTION
CRITICAL BUG FIX: Printer configurations now persist across addon restarts

Problem:
- Printers added through frontend were lost after addon restart
- Config was stored in /app/config/printers.json (ephemeral container storage)
- Only /data directory is persistent in HA addons

Solution:
- Changed printer config path to /data/printernizer/printers.json (persistent)
- ConfigService now auto-detects HA environment and uses persistent storage
- Added PRINTER_CONFIG_PATH environment variable in run.sh
- Added logging to show config path on startup

Changes:
- src/services/config_service.py: Auto-detect HA environment, use /data path
- printernizer/run.sh: Set PRINTER_CONFIG_PATH env var, add logging
- Bump version to 2.0.45
- Update CHANGELOG with fix details

Fixes issue where printer configurations were not persisting across
Home Assistant addon restarts.