### PR TITLE
feat: Add navigation bar customization to settings

### DIFF
--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -3310,3 +3310,212 @@ label .required {
     padding-top: 2rem;
     border-top: 2px solid var(--border-color, #e0e0e0);
 }
+
+/* Navigation Preferences Styles */
+.navigation-sections-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2, 0.5rem);
+    margin-top: var(--spacing-3, 0.75rem);
+}
+
+.navigation-section-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3, 0.75rem);
+    padding: var(--spacing-3, 0.75rem);
+    background: var(--gray-50, #f9fafb);
+    border: 1px solid var(--gray-200, #e5e7eb);
+    border-radius: var(--radius-md, 0.5rem);
+    cursor: move;
+    transition: all 0.2s ease;
+}
+
+.navigation-section-item:hover {
+    background: var(--gray-100, #f3f4f6);
+    border-color: var(--gray-300, #d1d5db);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.navigation-section-item.dragging {
+    opacity: 0.5;
+    cursor: grabbing;
+}
+
+.navigation-section-item.drag-over {
+    border-color: var(--primary-color, #3b82f6);
+    background: var(--primary-50, #eff6ff);
+}
+
+.navigation-section-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+    color: var(--gray-400, #9ca3af);
+    font-size: 1.25rem;
+}
+
+.navigation-section-handle:active {
+    cursor: grabbing;
+}
+
+.navigation-section-content {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3, 0.75rem);
+    flex: 1;
+    min-width: 0;
+}
+
+.navigation-section-icon {
+    font-size: 1.5rem;
+    flex-shrink: 0;
+}
+
+.navigation-section-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.navigation-section-label {
+    font-weight: 500;
+    color: var(--gray-900, #111827);
+    margin-bottom: var(--spacing-1, 0.25rem);
+}
+
+.navigation-section-description {
+    font-size: var(--font-size-sm, 0.875rem);
+    color: var(--gray-600, #6b7280);
+    line-height: 1.4;
+}
+
+.navigation-section-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2, 0.5rem);
+    flex-shrink: 0;
+}
+
+.btn-icon-small {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    background: transparent;
+    border: 1px solid var(--gray-300, #d1d5db);
+    border-radius: var(--radius-sm, 0.25rem);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-size: 1rem;
+}
+
+.btn-icon-small:hover:not(:disabled) {
+    background: var(--gray-100, #f3f4f6);
+    border-color: var(--gray-400, #9ca3af);
+}
+
+.btn-icon-small:active:not(:disabled) {
+    transform: scale(0.95);
+}
+
+.btn-icon-small:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+
+/* Toggle Switch */
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 3rem;
+    height: 1.75rem;
+    cursor: pointer;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--gray-300, #d1d5db);
+    border-radius: 1.75rem;
+    transition: 0.3s;
+}
+
+.toggle-slider:before {
+    position: absolute;
+    content: "";
+    height: 1.25rem;
+    width: 1.25rem;
+    left: 0.25rem;
+    bottom: 0.25rem;
+    background-color: white;
+    border-radius: 50%;
+    transition: 0.3s;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background-color: var(--success-color, #10b981);
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+    transform: translateX(1.25rem);
+}
+
+.toggle-switch input:disabled + .toggle-slider {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.toggle-switch input:focus + .toggle-slider {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* Dark Theme Support for Navigation Preferences */
+[data-theme="dark"] .navigation-section-item {
+    background: var(--gray-800, #1f2937);
+    border-color: var(--gray-700, #374151);
+}
+
+[data-theme="dark"] .navigation-section-item:hover {
+    background: var(--gray-700, #374151);
+    border-color: var(--gray-600, #4b5563);
+}
+
+[data-theme="dark"] .navigation-section-item.drag-over {
+    border-color: var(--primary-color, #3b82f6);
+    background: var(--gray-700, #374151);
+}
+
+[data-theme="dark"] .navigation-section-label {
+    color: var(--gray-100, #f3f4f6);
+}
+
+[data-theme="dark"] .navigation-section-description {
+    color: var(--gray-400, #9ca3af);
+}
+
+[data-theme="dark"] .btn-icon-small {
+    border-color: var(--gray-600, #4b5563);
+    color: var(--gray-300, #d1d5db);
+}
+
+[data-theme="dark"] .btn-icon-small:hover:not(:disabled) {
+    background: var(--gray-700, #374151);
+    border-color: var(--gray-500, #6b7280);
+}
+
+[data-theme="dark"] .toggle-slider {
+    background-color: var(--gray-600, #4b5563);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1004,6 +1004,32 @@
                         </div>
                     </div>
 
+                    <!-- Navigation Customization -->
+                    <div class="card settings-section">
+                        <div class="card-header">
+                            <h3>Navigationsleiste</h3>
+                            <span class="card-icon">🧭</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="form-group">
+                                <p class="text-muted">
+                                    Passen Sie die Reihenfolge und Sichtbarkeit der Navigationselemente an.
+                                </p>
+                            </div>
+
+                            <div id="navigationSectionsList" class="navigation-sections-list">
+                                <!-- Dynamic content will be inserted here -->
+                            </div>
+
+                            <div class="navigation-actions" style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
+                                <button class="btn btn-secondary" onclick="navigationPreferencesManager.resetNavigationPreferences()">
+                                    <span class="btn-icon">🔄</span>
+                                    Auf Standardeinstellungen zurücksetzen
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- System Information -->
                     <div class="card settings-section">
                         <div class="card-header">
@@ -1901,6 +1927,7 @@
     <script src="js/api.js"></script>
     <script src="js/websocket.js"></script>
     <script src="js/utils.js"></script>
+    <script src="js/navigation-preferences.js"></script>
     <script src="js/components.js"></script>
     <script src="js/milestone-1-2-functions.js"></script>
     <script src="js/printer-form.js"></script>
@@ -1912,6 +1939,7 @@
     <script src="js/files.js"></script>
     <script src="js/ideas.js"></script>
     <script src="js/settings.js?v=1.1"></script>
+    <script src="js/navigation-preferences-ui.js"></script>
     <script src="js/debug.js?v=1.1"></script>
 
     <!-- Auto-Download System -->

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -24,19 +24,24 @@ class PrinternizerApp {
      */
     init() {
         console.log('Initializing Printernizer application');
-        
+
+        // Apply navigation preferences
+        if (window.navigationPreferencesManager) {
+            window.navigationPreferencesManager.updateNavigation();
+        }
+
         // Setup navigation
         this.setupNavigation();
-        
+
         // Initialize current page
         this.showPage(this.currentPage);
-        
+
         // Setup global error handling
         this.setupErrorHandling();
-        
+
         // Check initial connection
         this.checkSystemHealth();
-        
+
         console.log('Printernizer application initialized');
     }
 

--- a/frontend/js/navigation-preferences-ui.js
+++ b/frontend/js/navigation-preferences-ui.js
@@ -1,0 +1,273 @@
+/**
+ * Navigation Preferences UI Manager
+ * Handles the UI for customizing navigation bar sections
+ */
+
+class NavigationPreferencesUIManager {
+    constructor() {
+        this.draggedElement = null;
+        this.draggedIndex = null;
+    }
+
+    /**
+     * Initialize the navigation preferences UI
+     */
+    init() {
+        this.renderNavigationSections();
+
+        // Listen for preference changes
+        window.addEventListener('navigationPreferencesChanged', () => {
+            this.renderNavigationSections();
+            this.updateNavigation();
+        });
+    }
+
+    /**
+     * Render the navigation sections list in settings
+     */
+    renderNavigationSections() {
+        const container = document.getElementById('navigationSectionsList');
+        if (!container) return;
+
+        const sections = window.navigationPreferences.getPreferences();
+
+        container.innerHTML = sections.map((section, index) => `
+            <div class="navigation-section-item"
+                 data-section-id="${section.id}"
+                 data-index="${index}"
+                 draggable="true">
+                <div class="navigation-section-handle" title="Ziehen zum Verschieben">
+                    <span class="handle-icon">☰</span>
+                </div>
+                <div class="navigation-section-content">
+                    <div class="navigation-section-icon">${section.icon}</div>
+                    <div class="navigation-section-info">
+                        <div class="navigation-section-label">${section.label}</div>
+                        <div class="navigation-section-description">${section.description}</div>
+                    </div>
+                </div>
+                <div class="navigation-section-controls">
+                    <button class="btn-icon-small"
+                            onclick="navigationPreferencesManager.moveSectionUp('${section.id}')"
+                            title="Nach oben"
+                            ${index === 0 ? 'disabled' : ''}>
+                        ⬆️
+                    </button>
+                    <button class="btn-icon-small"
+                            onclick="navigationPreferencesManager.moveSectionDown('${section.id}')"
+                            title="Nach unten"
+                            ${index === sections.length - 1 ? 'disabled' : ''}>
+                        ⬇️
+                    </button>
+                    <label class="toggle-switch" title="${section.required ? 'Erforderliches Element kann nicht ausgeblendet werden' : 'Sichtbarkeit umschalten'}">
+                        <input type="checkbox"
+                               ${section.visible ? 'checked' : ''}
+                               ${section.required ? 'disabled' : ''}
+                               onchange="navigationPreferencesManager.toggleSectionVisibility('${section.id}')">
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
+            </div>
+        `).join('');
+
+        // Setup drag and drop
+        this.setupDragAndDrop();
+    }
+
+    /**
+     * Setup drag and drop functionality
+     */
+    setupDragAndDrop() {
+        const items = document.querySelectorAll('.navigation-section-item');
+
+        items.forEach(item => {
+            item.addEventListener('dragstart', (e) => this.handleDragStart(e));
+            item.addEventListener('dragover', (e) => this.handleDragOver(e));
+            item.addEventListener('drop', (e) => this.handleDrop(e));
+            item.addEventListener('dragend', (e) => this.handleDragEnd(e));
+        });
+    }
+
+    /**
+     * Handle drag start
+     */
+    handleDragStart(e) {
+        this.draggedElement = e.currentTarget;
+        this.draggedIndex = parseInt(e.currentTarget.dataset.index);
+        e.currentTarget.classList.add('dragging');
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/html', e.currentTarget.innerHTML);
+    }
+
+    /**
+     * Handle drag over
+     */
+    handleDragOver(e) {
+        if (e.preventDefault) {
+            e.preventDefault();
+        }
+        e.dataTransfer.dropEffect = 'move';
+
+        const target = e.currentTarget;
+        if (target !== this.draggedElement) {
+            target.classList.add('drag-over');
+        }
+
+        return false;
+    }
+
+    /**
+     * Handle drop
+     */
+    handleDrop(e) {
+        if (e.stopPropagation) {
+            e.stopPropagation();
+        }
+
+        const target = e.currentTarget;
+        const targetIndex = parseInt(target.dataset.index);
+
+        if (this.draggedElement !== target && this.draggedIndex !== targetIndex) {
+            // Reorder sections
+            const sections = window.navigationPreferences.getPreferences();
+            const newOrder = [...sections];
+
+            // Remove dragged item
+            const [draggedItem] = newOrder.splice(this.draggedIndex, 1);
+
+            // Insert at new position
+            newOrder.splice(targetIndex, 0, draggedItem);
+
+            // Save new order
+            const newOrderIds = newOrder.map(s => s.id);
+            window.navigationPreferences.reorderSections(newOrderIds);
+        }
+
+        return false;
+    }
+
+    /**
+     * Handle drag end
+     */
+    handleDragEnd(e) {
+        e.currentTarget.classList.remove('dragging');
+
+        // Remove drag-over class from all items
+        document.querySelectorAll('.navigation-section-item').forEach(item => {
+            item.classList.remove('drag-over');
+        });
+    }
+
+    /**
+     * Move section up
+     */
+    moveSectionUp(sectionId) {
+        if (window.navigationPreferences.moveSectionUp(sectionId)) {
+            this.showSuccess('Abschnitt nach oben verschoben');
+        }
+    }
+
+    /**
+     * Move section down
+     */
+    moveSectionDown(sectionId) {
+        if (window.navigationPreferences.moveSectionDown(sectionId)) {
+            this.showSuccess('Abschnitt nach unten verschoben');
+        }
+    }
+
+    /**
+     * Toggle section visibility
+     */
+    toggleSectionVisibility(sectionId) {
+        if (window.navigationPreferences.toggleVisibility(sectionId)) {
+            this.showSuccess('Sichtbarkeit aktualisiert');
+        }
+    }
+
+    /**
+     * Reset navigation preferences
+     */
+    resetNavigationPreferences() {
+        if (confirm('Möchten Sie die Navigationsleiste auf die Standardeinstellungen zurücksetzen?')) {
+            if (window.navigationPreferences.resetToDefaults()) {
+                this.showSuccess('Navigation auf Standardeinstellungen zurückgesetzt');
+            }
+        }
+    }
+
+    /**
+     * Update the actual navigation bar
+     */
+    updateNavigation() {
+        const navMenu = document.querySelector('.nav-menu');
+        if (!navMenu) return;
+
+        const visibleSections = window.navigationPreferences.getVisibleSections();
+        const currentPage = window.app?.currentPage || 'dashboard';
+
+        // Clear existing nav links (but keep screen reader descriptions)
+        const srOnly = navMenu.querySelector('.sr-only');
+        navMenu.innerHTML = '';
+
+        // Add sections in order
+        visibleSections.forEach(section => {
+            const link = document.createElement('a');
+            link.href = `#${section.id}`;
+            link.className = 'nav-link';
+            link.setAttribute('data-page', section.id);
+            link.setAttribute('role', 'button');
+            link.setAttribute('aria-describedby', `nav-${section.id}-desc`);
+
+            if (section.id === currentPage) {
+                link.classList.add('active');
+                link.setAttribute('aria-current', 'page');
+            }
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'nav-icon';
+            iconSpan.setAttribute('aria-hidden', 'true');
+            iconSpan.textContent = section.icon;
+
+            link.appendChild(iconSpan);
+            link.appendChild(document.createTextNode('\n                    ' + section.label + '\n                '));
+
+            navMenu.appendChild(link);
+        });
+
+        // Re-add screen reader descriptions if they exist
+        if (srOnly) {
+            navMenu.appendChild(srOnly);
+        }
+    }
+
+    /**
+     * Show success message
+     */
+    showSuccess(message) {
+        if (window.showToast) {
+            window.showToast(message, 'success');
+        } else {
+            console.log(message);
+        }
+    }
+
+    /**
+     * Show error message
+     */
+    showError(message) {
+        if (window.showToast) {
+            window.showToast(message, 'error');
+        } else {
+            console.error(message);
+        }
+    }
+}
+
+// Create global instance
+window.navigationPreferencesManager = new NavigationPreferencesUIManager();
+
+// Initialize when settings page loads
+document.addEventListener('DOMContentLoaded', () => {
+    window.navigationPreferencesManager.init();
+});

--- a/frontend/js/navigation-preferences.js
+++ b/frontend/js/navigation-preferences.js
@@ -1,0 +1,246 @@
+/**
+ * Navigation Preferences Manager
+ * Handles customization of navigation bar sections (order and visibility)
+ */
+
+class NavigationPreferences {
+    constructor() {
+        this.storageKey = 'printernizer-navigation-preferences';
+
+        // Default navigation sections in their default order
+        this.defaultSections = [
+            {
+                id: 'dashboard',
+                icon: '📊',
+                label: 'Dashboard',
+                description: 'Übersichtsseite mit Druckerstatus und aktuellen Aufträgen',
+                visible: true,
+                required: true // Cannot be hidden
+            },
+            {
+                id: 'printers',
+                icon: '🖨️',
+                label: 'Drucker',
+                description: 'Verwaltung und Konfiguration der 3D-Drucker',
+                visible: true,
+                required: false
+            },
+            {
+                id: 'jobs',
+                icon: '⚙️',
+                label: 'Aufträge',
+                description: 'Übersicht und Verwaltung der Druckaufträge',
+                visible: true,
+                required: false
+            },
+            {
+                id: 'files',
+                icon: '📁',
+                label: 'Dateien',
+                description: 'Dateiverwaltung und Downloads von den Druckern',
+                visible: true,
+                required: false
+            },
+            {
+                id: 'library',
+                icon: '🗄️',
+                label: 'Bibliothek',
+                description: 'Zentrale Bibliothek für alle 3D-Dateien mit Metadaten',
+                visible: true,
+                required: false
+            },
+            {
+                id: 'materials',
+                icon: '🧵',
+                label: 'Filamente',
+                description: 'Filament-Verwaltung und Bestandsübersicht',
+                visible: true,
+                required: false
+            },
+            {
+                id: 'ideas',
+                icon: '💡',
+                label: 'Ideen',
+                description: 'Ideenverwaltung, Lesezeichen und Modell-Entdeckung',
+                visible: true,
+                required: false
+            },
+            {
+                id: 'settings',
+                icon: '⚙️',
+                label: 'Einstellungen',
+                description: 'Anwendungseinstellungen und Konfiguration',
+                visible: true,
+                required: true // Cannot be hidden
+            },
+            {
+                id: 'debug',
+                icon: '🐛',
+                label: 'Debug',
+                description: 'Debug-Informationen und Systemprotokolle',
+                visible: true,
+                required: false
+            }
+        ];
+    }
+
+    /**
+     * Get current navigation preferences (merged with defaults)
+     */
+    getPreferences() {
+        try {
+            const stored = localStorage.getItem(this.storageKey);
+            if (!stored) {
+                return this.defaultSections;
+            }
+
+            const preferences = JSON.parse(stored);
+
+            // Merge stored preferences with defaults to handle new sections
+            const merged = this.defaultSections.map(defaultSection => {
+                const storedSection = preferences.find(p => p.id === defaultSection.id);
+                return storedSection ? { ...defaultSection, ...storedSection } : defaultSection;
+            });
+
+            // Add any stored sections that don't exist in defaults (for backwards compatibility)
+            preferences.forEach(storedSection => {
+                if (!merged.find(m => m.id === storedSection.id)) {
+                    merged.push(storedSection);
+                }
+            });
+
+            return merged;
+        } catch (error) {
+            console.error('Error loading navigation preferences:', error);
+            return this.defaultSections;
+        }
+    }
+
+    /**
+     * Save navigation preferences
+     */
+    savePreferences(preferences) {
+        try {
+            localStorage.setItem(this.storageKey, JSON.stringify(preferences));
+
+            // Dispatch custom event for other components to react
+            window.dispatchEvent(new CustomEvent('navigationPreferencesChanged', {
+                detail: { preferences }
+            }));
+
+            return true;
+        } catch (error) {
+            console.error('Error saving navigation preferences:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Reset to default preferences
+     */
+    resetToDefaults() {
+        try {
+            localStorage.removeItem(this.storageKey);
+
+            // Dispatch custom event
+            window.dispatchEvent(new CustomEvent('navigationPreferencesChanged', {
+                detail: { preferences: this.defaultSections }
+            }));
+
+            return true;
+        } catch (error) {
+            console.error('Error resetting navigation preferences:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Get visible sections in the correct order
+     */
+    getVisibleSections() {
+        return this.getPreferences().filter(section => section.visible);
+    }
+
+    /**
+     * Toggle visibility of a section
+     */
+    toggleVisibility(sectionId) {
+        const preferences = this.getPreferences();
+        const section = preferences.find(s => s.id === sectionId);
+
+        if (!section) {
+            console.error('Section not found:', sectionId);
+            return false;
+        }
+
+        if (section.required) {
+            console.warn('Cannot hide required section:', sectionId);
+            return false;
+        }
+
+        section.visible = !section.visible;
+        return this.savePreferences(preferences);
+    }
+
+    /**
+     * Reorder sections
+     */
+    reorderSections(newOrder) {
+        const preferences = this.getPreferences();
+        const reordered = [];
+
+        // Build new array based on newOrder (array of IDs)
+        newOrder.forEach(id => {
+            const section = preferences.find(s => s.id === id);
+            if (section) {
+                reordered.push(section);
+            }
+        });
+
+        // Add any sections not in newOrder (shouldn't happen, but safety check)
+        preferences.forEach(section => {
+            if (!reordered.find(s => s.id === section.id)) {
+                reordered.push(section);
+            }
+        });
+
+        return this.savePreferences(reordered);
+    }
+
+    /**
+     * Move a section up in the order
+     */
+    moveSectionUp(sectionId) {
+        const preferences = this.getPreferences();
+        const index = preferences.findIndex(s => s.id === sectionId);
+
+        if (index <= 0) {
+            return false; // Already at the top or not found
+        }
+
+        // Swap with previous section
+        [preferences[index - 1], preferences[index]] = [preferences[index], preferences[index - 1]];
+
+        return this.savePreferences(preferences);
+    }
+
+    /**
+     * Move a section down in the order
+     */
+    moveSectionDown(sectionId) {
+        const preferences = this.getPreferences();
+        const index = preferences.findIndex(s => s.id === sectionId);
+
+        if (index < 0 || index >= preferences.length - 1) {
+            return false; // Already at the bottom or not found
+        }
+
+        // Swap with next section
+        [preferences[index], preferences[index + 1]] = [preferences[index + 1], preferences[index]];
+
+        return this.savePreferences(preferences);
+    }
+}
+
+// Create global instance
+window.navigationPreferences = new NavigationPreferences();


### PR DESCRIPTION
- Add new "Navigationsleiste" section in settings page
- Users can reorder navigation sections via drag-and-drop or up/down buttons
- Users can hide/show individual navigation sections (except Dashboard and Settings which are required)
- Preferences stored in localStorage for persistence
- Includes toggle switches for visibility control
- Fully responsive with dark theme support
- Navigation updates immediately when preferences change

Files added:
- frontend/js/navigation-preferences.js - Core preference management
- frontend/js/navigation-preferences-ui.js - UI manager with drag-and-drop

Files modified:
- frontend/index.html - Added settings section and script tags
- frontend/js/main.js - Apply preferences on app initialization
- frontend/css/components.css - Added styling for drag-and-drop UI