### PR TITLE
fix: Add responsive mobile navigation with hamburger menu

### DIFF
--- a/frontend/css/dark-theme.css
+++ b/frontend/css/dark-theme.css
@@ -690,3 +690,27 @@
 .spinner {
     transition: none;
 }
+
+/* Hamburger Menu Button */
+[data-theme="dark"] .hamburger,
+[data-theme="dark"] .hamburger::before,
+[data-theme="dark"] .hamburger::after {
+    background-color: #e0e0e0;
+}
+
+[data-theme="dark"] .nav-toggle[aria-expanded="true"] .hamburger {
+    background-color: transparent;
+}
+
+/* Mobile Navigation Menu */
+@media (max-width: 640px) {
+    [data-theme="dark"] .nav-menu {
+        background: #1a1a1a;
+        border-bottom: 1px solid #3a3a3a;
+        box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.3);
+    }
+
+    [data-theme="dark"] .nav-link {
+        border-bottom: 1px solid #2d2d2d;
+    }
+}

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -157,6 +157,27 @@ p {
 .nav-menu {
     display: flex;
     gap: var(--spacing-2);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    scrollbar-color: var(--gray-400) transparent;
+}
+
+.nav-menu::-webkit-scrollbar {
+    height: 4px;
+}
+
+.nav-menu::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.nav-menu::-webkit-scrollbar-thumb {
+    background-color: var(--gray-400);
+    border-radius: 2px;
+}
+
+.nav-menu::-webkit-scrollbar-thumb:hover {
+    background-color: var(--gray-500);
 }
 
 .nav-link {
@@ -183,6 +204,66 @@ p {
 
 .nav-icon {
     font-size: var(--font-size-sm);
+}
+
+/* Hamburger Menu Button */
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    position: relative;
+    z-index: 101;
+}
+
+.hamburger,
+.hamburger::before,
+.hamburger::after {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background-color: var(--gray-700);
+    border-radius: 2px;
+    transition: all 0.3s ease;
+}
+
+.hamburger {
+    position: relative;
+}
+
+.hamburger::before,
+.hamburger::after {
+    content: '';
+    position: absolute;
+    left: 0;
+}
+
+.hamburger::before {
+    top: -8px;
+}
+
+.hamburger::after {
+    top: 8px;
+}
+
+.nav-toggle[aria-expanded="true"] .hamburger {
+    background-color: transparent;
+}
+
+.nav-toggle[aria-expanded="true"] .hamburger::before {
+    top: 0;
+    transform: rotate(45deg);
+}
+
+.nav-toggle[aria-expanded="true"] .hamburger::after {
+    top: 0;
+    transform: rotate(-45deg);
 }
 
 .nav-status {
@@ -735,39 +816,70 @@ p {
 
 /* Responsive Design - Mobile First */
 @media (max-width: 640px) {
+    .nav-toggle {
+        display: flex;
+    }
+
     .nav-menu {
         display: none;
+        position: fixed;
+        top: var(--navbar-height);
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        gap: 0;
+        background: var(--white);
+        border-bottom: 1px solid var(--gray-200);
+        box-shadow: var(--shadow-lg);
+        max-height: calc(100vh - var(--navbar-height));
+        overflow-y: auto;
+        overflow-x: hidden;
+        z-index: 99;
     }
-    
+
+    .nav-menu.active {
+        display: flex;
+    }
+
+    .nav-link {
+        padding: var(--spacing-4);
+        border-bottom: 1px solid var(--gray-100);
+        border-radius: 0;
+    }
+
+    .nav-link:last-child {
+        border-bottom: none;
+    }
+
     .main-content {
         padding: var(--spacing-4);
     }
-    
+
     .page-header {
         flex-direction: column;
         align-items: flex-start;
         gap: var(--spacing-3);
     }
-    
+
     .header-actions {
         width: 100%;
         justify-content: flex-end;
     }
-    
+
     .filter-controls {
         flex-direction: column;
         width: 100%;
     }
-    
+
     .filter-select {
         width: 100%;
     }
-    
+
     .btn {
         padding: var(--spacing-2) var(--spacing-3);
         font-size: var(--font-size-sm);
     }
-    
+
     .card-body {
         padding: var(--spacing-4);
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,9 @@
                 <img src="assets/logo.png" alt="Printernizer" class="logo">
                 <span class="brand-text">Printernizer</span>
             </div>
+            <button class="nav-toggle" id="navToggle" aria-label="Navigation umschalten" aria-expanded="false">
+                <span class="hamburger"></span>
+            </button>
             <div class="nav-menu" role="navigation" aria-label="Hauptnavigation">
                 <a href="#dashboard" class="nav-link active" data-page="dashboard" 
                    role="button" aria-current="page" aria-describedby="nav-dashboard-desc">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -49,6 +49,35 @@ class PrinternizerApp {
      * Setup navigation event handlers
      */
     setupNavigation() {
+        // Handle hamburger menu toggle
+        const navToggle = document.getElementById('navToggle');
+        const navMenu = document.querySelector('.nav-menu');
+
+        if (navToggle && navMenu) {
+            navToggle.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+                navToggle.setAttribute('aria-expanded', !isExpanded);
+                navMenu.classList.toggle('active');
+            });
+
+            // Close menu when clicking outside
+            document.addEventListener('click', (e) => {
+                if (!navMenu.contains(e.target) && !navToggle.contains(e.target)) {
+                    navToggle.setAttribute('aria-expanded', 'false');
+                    navMenu.classList.remove('active');
+                }
+            });
+
+            // Close menu when clicking a nav link (mobile)
+            navMenu.addEventListener('click', (e) => {
+                if (e.target.classList.contains('nav-link')) {
+                    navToggle.setAttribute('aria-expanded', 'false');
+                    navMenu.classList.remove('active');
+                }
+            });
+        }
+
         // Handle navigation clicks
         document.addEventListener('click', (e) => {
             const navLink = e.target.closest('.nav-link[data-page]');
@@ -58,19 +87,19 @@ class PrinternizerApp {
                 this.showPage(page);
             }
         });
-        
+
         // Handle back/forward browser navigation
         window.addEventListener('popstate', (e) => {
             const page = e.state?.page || 'dashboard';
             this.showPage(page, false);
         });
-        
+
         // Set initial browser state
         const currentHash = window.location.hash.slice(1) || 'dashboard';
         if (['dashboard', 'printers', 'jobs', 'files', 'library', 'materials', 'ideas', 'settings', 'debug'].includes(currentHash)) {
             this.currentPage = currentHash;
         }
-        
+
         history.replaceState({ page: this.currentPage }, '', `#${this.currentPage}`);
     }
 

--- a/frontend/js/navigation-preferences-ui.js
+++ b/frontend/js/navigation-preferences-ui.js
@@ -206,6 +206,13 @@ class NavigationPreferencesUIManager {
         const visibleSections = window.navigationPreferences.getVisibleSections();
         const currentPage = window.app?.currentPage || 'dashboard';
 
+        // Close mobile menu if open
+        const navToggle = document.getElementById('navToggle');
+        if (navToggle) {
+            navToggle.setAttribute('aria-expanded', 'false');
+            navMenu.classList.remove('active');
+        }
+
         // Clear existing nav links (but keep screen reader descriptions)
         const srOnly = navMenu.querySelector('.sr-only');
         navMenu.innerHTML = '';


### PR DESCRIPTION
- Add hamburger menu button for mobile devices (≤640px)
- Implement collapsible dropdown navigation menu on mobile
- Add horizontal scrolling for navigation overflow on wide screens
- Add dark theme support for hamburger menu and mobile navigation
- Auto-close mobile menu when clicking nav links or outside menu
- Close mobile menu when updating navigation preferences

Fixes issues where navigation was completely hidden on mobile
portrait mode and items were cut off on wide screens.