### PR TITLE
feat: Add download path validator to settings tab

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -920,6 +920,17 @@
                                     <input type="text" id="downloadsPath" name="downloads_path" class="form-control" placeholder="z.B. C:\Downloads\Printernizer">
                                     <small class="form-text text-muted">Verzeichnis für heruntergeladene Dateien</small>
                                 </div>
+
+                                <div class="form-group">
+                                    <div class="validation-result" id="downloadsPathValidationResult" style="display: none;"></div>
+                                </div>
+
+                                <div class="form-group">
+                                    <button type="button" class="btn btn-secondary" onclick="validateDownloadsPath()">
+                                        <span class="btn-icon">✓</span>
+                                        Pfad validieren
+                                    </button>
+                                </div>
                                 
                                 <div class="form-group">
                                     <label for="maxFileSize">Max. Dateigröße (MB)</label>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -318,6 +318,10 @@ class ApiClient {
         return this.post('/files/watch-folders/validate?folder_path=' + encodeURIComponent(folderPath));
     }
 
+    async validateDownloadsPath(folderPath) {
+        return this.post('/settings/downloads-path/validate?folder_path=' + encodeURIComponent(folderPath));
+    }
+
     async addWatchFolder(folderPath) {
         return this.post('/files/watch-folders/add?folder_path=' + encodeURIComponent(folderPath));
     }

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -492,6 +492,42 @@ async function shutdownServer() {
     }
 }
 
+async function validateDownloadsPath() {
+    const folderPathInput = document.getElementById('downloadsPath');
+    const validationResult = document.getElementById('downloadsPathValidationResult');
+
+    if (!folderPathInput || !validationResult) return;
+
+    const folderPath = folderPathInput.value.trim();
+    if (!folderPath) {
+        validationResult.style.display = 'none';
+        return;
+    }
+
+    try {
+        // Show loading state
+        validationResult.style.display = 'block';
+        validationResult.className = 'validation-result loading';
+        validationResult.innerHTML = '<span class="spinner-small"></span> Validiere...';
+
+        // Validate path
+        const response = await api.validateDownloadsPath(folderPath);
+
+        if (response.valid) {
+            validationResult.className = 'validation-result success';
+            validationResult.innerHTML = '<span class="icon">✓</span> ' + (response.message || 'Download-Verzeichnis ist gültig und beschreibbar');
+        } else {
+            validationResult.className = 'validation-result error';
+            validationResult.innerHTML = '<span class="icon">✗</span> ' + (response.error || 'Download-Verzeichnis ist ungültig');
+        }
+
+    } catch (error) {
+        console.error('Failed to validate downloads path:', error);
+        validationResult.className = 'validation-result error';
+        validationResult.innerHTML = '<span class="icon">✗</span> Validierung fehlgeschlagen';
+    }
+}
+
 // Export for use in main.js
 if (typeof window !== 'undefined') {
     window.settingsManager = settingsManager;

--- a/printernizer/frontend/index.html
+++ b/printernizer/frontend/index.html
@@ -920,6 +920,17 @@
                                     <input type="text" id="downloadsPath" name="downloads_path" class="form-control" placeholder="z.B. C:\Downloads\Printernizer">
                                     <small class="form-text text-muted">Verzeichnis für heruntergeladene Dateien</small>
                                 </div>
+
+                                <div class="form-group">
+                                    <div class="validation-result" id="downloadsPathValidationResult" style="display: none;"></div>
+                                </div>
+
+                                <div class="form-group">
+                                    <button type="button" class="btn btn-secondary" onclick="validateDownloadsPath()">
+                                        <span class="btn-icon">✓</span>
+                                        Pfad validieren
+                                    </button>
+                                </div>
                                 
                                 <div class="form-group">
                                     <label for="maxFileSize">Max. Dateigröße (MB)</label>

--- a/printernizer/frontend/js/api.js
+++ b/printernizer/frontend/js/api.js
@@ -318,6 +318,10 @@ class ApiClient {
         return this.post('/files/watch-folders/validate?folder_path=' + encodeURIComponent(folderPath));
     }
 
+    async validateDownloadsPath(folderPath) {
+        return this.post('/settings/downloads-path/validate?folder_path=' + encodeURIComponent(folderPath));
+    }
+
     async addWatchFolder(folderPath) {
         return this.post('/files/watch-folders/add?folder_path=' + encodeURIComponent(folderPath));
     }

--- a/printernizer/frontend/js/settings.js
+++ b/printernizer/frontend/js/settings.js
@@ -492,6 +492,42 @@ async function shutdownServer() {
     }
 }
 
+async function validateDownloadsPath() {
+    const folderPathInput = document.getElementById('downloadsPath');
+    const validationResult = document.getElementById('downloadsPathValidationResult');
+
+    if (!folderPathInput || !validationResult) return;
+
+    const folderPath = folderPathInput.value.trim();
+    if (!folderPath) {
+        validationResult.style.display = 'none';
+        return;
+    }
+
+    try {
+        // Show loading state
+        validationResult.style.display = 'block';
+        validationResult.className = 'validation-result loading';
+        validationResult.innerHTML = '<span class="spinner-small"></span> Validiere...';
+
+        // Validate path
+        const response = await api.validateDownloadsPath(folderPath);
+
+        if (response.valid) {
+            validationResult.className = 'validation-result success';
+            validationResult.innerHTML = '<span class="icon">✓</span> ' + (response.message || 'Download-Verzeichnis ist gültig und beschreibbar');
+        } else {
+            validationResult.className = 'validation-result error';
+            validationResult.innerHTML = '<span class="icon">✗</span> ' + (response.error || 'Download-Verzeichnis ist ungültig');
+        }
+
+    } catch (error) {
+        console.error('Failed to validate downloads path:', error);
+        validationResult.className = 'validation-result error';
+        validationResult.innerHTML = '<span class="icon">✗</span> Validierung fehlgeschlagen';
+    }
+}
+
 // Export for use in main.js
 if (typeof window !== 'undefined') {
     window.settingsManager = settingsManager;

--- a/printernizer/src/api/routers/settings.py
+++ b/printernizer/src/api/routers/settings.py
@@ -263,6 +263,23 @@ async def validate_watch_folder(
         )
 
 
+@router.post("/downloads-path/validate")
+async def validate_downloads_path(
+    folder_path: str,
+    config_service: ConfigService = Depends(get_config_service)
+):
+    """Validate the downloads path - check if it's available, writable, and deletable."""
+    try:
+        result = config_service.validate_downloads_path(folder_path)
+        return result
+    except Exception as e:
+        logger.error("Failed to validate downloads path", folder_path=folder_path, error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to validate downloads path"
+        )
+
+
 class GcodeOptimizationSettings(BaseModel):
     """G-code optimization settings model."""
     optimize_print_only: bool

--- a/src/api/routers/settings.py
+++ b/src/api/routers/settings.py
@@ -263,6 +263,23 @@ async def validate_watch_folder(
         )
 
 
+@router.post("/downloads-path/validate")
+async def validate_downloads_path(
+    folder_path: str,
+    config_service: ConfigService = Depends(get_config_service)
+):
+    """Validate the downloads path - check if it's available, writable, and deletable."""
+    try:
+        result = config_service.validate_downloads_path(folder_path)
+        return result
+    except Exception as e:
+        logger.error("Failed to validate downloads path", folder_path=folder_path, error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to validate downloads path"
+        )
+
+
 class GcodeOptimizationSettings(BaseModel):
     """G-code optimization settings model."""
     optimize_print_only: bool


### PR DESCRIPTION
- Added validation button and result display for downloads_path field in settings UI
- Created backend API endpoint to validate download path at /settings/downloads-path/validate
- Implemented validate_downloads_path method in ConfigService to check:
  - Path existence (creates if missing)
  - Directory verification
  - Read/write/delete permissions
  - Actual file write and delete test
- Added frontend validateDownloadsPath function in settings.js
- Added API client method in api.js
- Synced changes to Home Assistant add-on directories

The validator ensures the download path is available, writable, and that files can be deleted.