### PR TITLE
fix: improve mobile menu layout and branding visibility

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -818,6 +818,19 @@ p {
 @media (max-width: 640px) {
     .nav-toggle {
         display: flex;
+        order: -1; /* Move hamburger menu to the left */
+    }
+
+    .nav-brand {
+        order: 0;
+    }
+
+    .nav-status {
+        order: 1;
+    }
+
+    .brand-text {
+        display: none; /* Hide "Printernizer" text in portrait mode */
     }
 
     .nav-menu {


### PR DESCRIPTION
- Move hamburger menu button to the left side in mobile view using flexbox order
- Hide "Printernizer" brand text in portrait mode to save space
- Maintain logo visibility for brand recognition on small screens