### PR TITLE
fix: Update version fallback to 2.3.7 and create git tag

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -87,7 +87,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.3.0")
+APP_VERSION = get_version(fallback="2.3.7")
 
 
 # Prometheus metrics - initialized once

--- a/src/utils/version.py
+++ b/src/utils/version.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 
-def get_version(fallback: str = "2.3.0") -> str:
+def get_version(fallback: str = "2.3.7") -> str:
     """
     Get application version from git tags.
 
@@ -46,7 +46,7 @@ def get_version(fallback: str = "2.3.0") -> str:
     return fallback
 
 
-def get_short_version(fallback: str = "2.3.0") -> str:
+def get_short_version(fallback: str = "2.3.7") -> str:
     """
     Get short version (major.minor.patch only).
 


### PR DESCRIPTION
- Updated fallback version from 2.3.0 to 2.3.7 in src/main.py
- Updated default fallback in src/utils/version.py to 2.3.7
- Created git tag v2.3.7 for proper version detection
- Ensures version displays correctly in Home Assistant add-on footer

Fixes version mismatch where HA add-on config.yaml shows 2.3.7
but application footer displayed 2.3.0 due to missing git tags
and fallback version being outdated.