### PR TITLE
fix: Use proper default folders for Home Assistant addon

### DIFF
--- a/printernizer/run.sh
+++ b/printernizer/run.sh
@@ -79,6 +79,7 @@ PRINTER_CONFIG_PATH=/data/printernizer/printers.json
 
 # File paths (persistent storage in /data)
 LIBRARY_PATH=${LIBRARY_FOLDER}
+DOWNLOADS_PATH=/data/printernizer/printer-files
 UPLOAD_PATH=/data/printernizer/printer-files
 BACKUP_PATH=/data/printernizer/backups
 CACHE_PATH=/data/printernizer/preview-cache

--- a/printernizer/src/services/file_download_service.py
+++ b/printernizer/src/services/file_download_service.py
@@ -350,7 +350,7 @@ class FileDownloadService:
             ValueError: If path creation fails or path traversal detected
         """
         # Get download path from configuration
-        base_download_path = "downloads"  # fallback default
+        base_download_path = "/data/printernizer/printer-files"  # fallback default for HA addon
         if self.config_service:
             try:
                 base_download_path = self.config_service.settings.downloads_path

--- a/printernizer/src/utils/config.py
+++ b/printernizer/src/utils/config.py
@@ -29,7 +29,7 @@ class PrinternizerSettings(BaseSettings):
 
     # Database Configuration
     database_path: str = Field(
-        default="/app/data/printernizer.db",
+        default="/data/printernizer/printernizer.db",
         env="DATABASE_PATH",
         description="Path to SQLite database file. Parent directory must exist and be writable."
     )
@@ -85,7 +85,7 @@ class PrinternizerSettings(BaseSettings):
 
     # File Management
     downloads_path: str = Field(
-        default="downloads",
+        default="/data/printernizer/printer-files",
         env="DOWNLOADS_PATH",
         description="Directory path for downloaded files. Will be created if it doesn't exist."
     )
@@ -230,7 +230,7 @@ class PrinternizerSettings(BaseSettings):
         description="Enable library system for file organization and management."
     )
     library_path: str = Field(
-        default="/app/data/library",
+        default="/data/printernizer/library",
         env="LIBRARY_PATH",
         description="Directory path for library files. Must be absolute path. Will be created if doesn't exist."
     )
@@ -288,12 +288,12 @@ class PrinternizerSettings(BaseSettings):
         description="Enable timelapse video creation feature"
     )
     timelapse_source_folder: str = Field(
-        default="/app/data/timelapse-images",
+        default="/data/timelapse-images",
         env="TIMELAPSE_SOURCE_FOLDER",
         description="Folder to watch for timelapse image subfolders. Will be created if doesn't exist."
     )
     timelapse_output_folder: str = Field(
-        default="/app/data/timelapses",
+        default="/data/timelapses",
         env="TIMELAPSE_OUTPUT_FOLDER",
         description="Folder for completed timelapse videos. Will be created if doesn't exist."
     )
@@ -435,7 +435,7 @@ class PrinternizerSettings(BaseSettings):
     def validate_library_path(cls, v):
         """Validate library path is absolute."""
         if not v:
-            return "/app/data/library"  # Default
+            return "/data/printernizer/library"  # Default for HA addon
 
         path = Path(v)
 

--- a/src/services/file_download_service.py
+++ b/src/services/file_download_service.py
@@ -350,7 +350,7 @@ class FileDownloadService:
             ValueError: If path creation fails or path traversal detected
         """
         # Get download path from configuration
-        base_download_path = "downloads"  # fallback default
+        base_download_path = "/data/printernizer/printer-files"  # fallback default for HA addon
         if self.config_service:
             try:
                 base_download_path = self.config_service.settings.downloads_path

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -29,7 +29,7 @@ class PrinternizerSettings(BaseSettings):
 
     # Database Configuration
     database_path: str = Field(
-        default="/app/data/printernizer.db",
+        default="/data/printernizer/printernizer.db",
         env="DATABASE_PATH",
         description="Path to SQLite database file. Parent directory must exist and be writable."
     )
@@ -85,7 +85,7 @@ class PrinternizerSettings(BaseSettings):
 
     # File Management
     downloads_path: str = Field(
-        default="downloads",
+        default="/data/printernizer/printer-files",
         env="DOWNLOADS_PATH",
         description="Directory path for downloaded files. Will be created if it doesn't exist."
     )
@@ -230,7 +230,7 @@ class PrinternizerSettings(BaseSettings):
         description="Enable library system for file organization and management."
     )
     library_path: str = Field(
-        default="/app/data/library",
+        default="/data/printernizer/library",
         env="LIBRARY_PATH",
         description="Directory path for library files. Must be absolute path. Will be created if doesn't exist."
     )
@@ -288,12 +288,12 @@ class PrinternizerSettings(BaseSettings):
         description="Enable timelapse video creation feature"
     )
     timelapse_source_folder: str = Field(
-        default="/app/data/timelapse-images",
+        default="/data/timelapse-images",
         env="TIMELAPSE_SOURCE_FOLDER",
         description="Folder to watch for timelapse image subfolders. Will be created if doesn't exist."
     )
     timelapse_output_folder: str = Field(
-        default="/app/data/timelapses",
+        default="/data/timelapses",
         env="TIMELAPSE_OUTPUT_FOLDER",
         description="Folder for completed timelapse videos. Will be created if doesn't exist."
     )
@@ -435,7 +435,7 @@ class PrinternizerSettings(BaseSettings):
     def validate_library_path(cls, v):
         """Validate library path is absolute."""
         if not v:
-            return "/app/data/library"  # Default
+            return "/data/printernizer/library"  # Default for HA addon
 
         path = Path(v)
 


### PR DESCRIPTION
Update default folder paths to use Home Assistant addon-compatible
absolute paths instead of relative or /app paths that don't work
properly in the HA addon environment.

Changes:
- downloads_path: "downloads" → "/data/printernizer/printer-files"
- library_path: "/app/data/library" → "/data/printernizer/library"
- database_path: "/app/data/printernizer.db" → "/data/printernizer/printernizer.db"
- timelapse_source: "/app/data/timelapse-images" → "/data/timelapse-images"
- timelapse_output: "/app/data/timelapses" → "/data/timelapses"

Also updated:
- file_download_service.py fallback path to use absolute HA addon path
- run.sh to explicitly set DOWNLOADS_PATH in environment
- library_path validator fallback to match HA addon structure

This ensures all folders work correctly when no configuration is
provided, using persistent storage in /data which is properly mounted
in the Home Assistant addon.