### PR TITLE
fix: Improve Home Assistant Ingress detection using pathname instead of port

### DIFF
--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -21,10 +21,11 @@ const getApiBaseUrl = () => {
 
     debugLog('Detecting API Base URL', { host, port, protocol, pathname, href });
 
-    // If accessed through HA Ingress (no port in URL) or on port 8123, use absolute-path-relative URLs
-    // Home Assistant Ingress proxies requests through /api/hassio_ingress/<token>/
-    // We extract the base path and construct absolute-path-relative URLs (starting with /)
-    if (!port || port === '8123') {
+    // Detect Home Assistant Ingress mode by checking pathname
+    // This is more reliable than port detection as it works with reverse proxies and custom ports
+    const isIngressMode = pathname.includes('/api/hassio_ingress/');
+
+    if (isIngressMode) {
         // Extract the ingress base path from pathname
         // Pathname will be like: /api/hassio_ingress/<token>/ or /api/hassio_ingress/<token>/index.html
         // We need to preserve the base path including the trailing slash
@@ -46,7 +47,7 @@ const getApiBaseUrl = () => {
             apiUrl,
             pathname,
             basePath,
-            reason: !port ? 'no port' : 'port 8123',
+            detection: 'pathname contains /api/hassio_ingress/',
             note: 'Absolute-path-relative URL includes ingress proxy path'
         });
 
@@ -67,10 +68,11 @@ const getWebSocketUrl = () => {
 
     debugLog('Detecting WebSocket URL', { host, port, protocol, pathname });
 
-    // If accessed through HA Ingress (no port in URL) or on port 8123, use absolute-path-relative WebSocket path
-    // Home Assistant Ingress proxies WebSocket connections through /api/hassio_ingress/<token>/
-    // We extract the base path and construct the WebSocket URL with full absolute path
-    if (!port || port === '8123') {
+    // Detect Home Assistant Ingress mode by checking pathname
+    // This is more reliable than port detection as it works with reverse proxies and custom ports
+    const isIngressMode = pathname.includes('/api/hassio_ingress/');
+
+    if (isIngressMode) {
         // Extract the ingress base path from pathname
         let basePath = pathname;
 
@@ -91,6 +93,7 @@ const getWebSocketUrl = () => {
             wsUrl,
             pathname,
             basePath,
+            detection: 'pathname contains /api/hassio_ingress/',
             note: 'WebSocket URL with absolute path includes ingress proxy path'
         });
 


### PR DESCRIPTION
Changes ingress mode detection from port-based to pathname-based, making it
more reliable across different Home Assistant configurations.

Problem:
- Previous implementation used port detection (!port || port === '8123')
- This failed when HA is behind reverse proxies or uses custom ports
- Led to frontend/backend connection failures in ingress mode

Solution:
- Detect ingress mode by checking if pathname contains '/api/hassio_ingress/'
- This is a definitive indicator of ingress mode regardless of port configuration
- Works reliably with reverse proxies, custom ports, and all HA setups

Changes:
- Updated getApiBaseUrl() to use pathname.includes('/api/hassio_ingress/')
- Updated getWebSocketUrl() to use the same detection method
- Added improved debug logging for troubleshooting

Benefits:
- More robust ingress detection
- Compatible with reverse proxies and custom HA configurations
- Maintains backward compatibility with direct access mode (port 8000)

Fixes: Home Assistant Ingress connection issues across various configurations