### PR TITLE
fix: Resolve Docker startup 'entrypoint.sh not found' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ python -m http.server 3000
 
 Run Printernizer in a Docker container for production deployments:
 
+**Using Docker Compose (Recommended):**
 ```bash
 # From project root
 cd docker
@@ -164,6 +165,15 @@ docker-compose logs -f
 # Stop
 docker-compose down
 ```
+
+**Using Build Script:**
+```bash
+# From project root
+./build-docker.sh
+docker run -d -p 8000:8000 --name printernizer printernizer:latest
+```
+
+⚠️ **Important**: If building manually, you must use the repository root as the build context. See [docker/README.md](docker/README.md) for details.
 
 **Features:**
 - Persistent data storage via Docker volumes

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Printernizer - Docker Build Script
+# Ensures correct build context and prevents "entrypoint.sh not found" errors
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=====================================${NC}"
+echo -e "${GREEN}🖨️  Printernizer Docker Build${NC}"
+echo -e "${GREEN}=====================================${NC}"
+echo ""
+
+# Ensure we're in the repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Verify required files exist
+echo -e "${YELLOW}Verifying build requirements...${NC}"
+required_files=(
+    "docker/Dockerfile"
+    "docker/entrypoint.sh"
+    "src"
+    "frontend"
+    "database_schema.sql"
+)
+
+for file in "${required_files[@]}"; do
+    if [ ! -e "$file" ]; then
+        echo -e "${RED}❌ Error: Required file/directory not found: $file${NC}"
+        echo -e "${RED}   Make sure you're running this script from the repository root${NC}"
+        exit 1
+    fi
+done
+
+echo -e "${GREEN}✅ All required files found${NC}"
+echo ""
+
+# Parse arguments
+IMAGE_NAME="${1:-printernizer}"
+IMAGE_TAG="${2:-latest}"
+
+echo -e "${YELLOW}Building Docker image...${NC}"
+echo -e "   Image: ${GREEN}${IMAGE_NAME}:${IMAGE_TAG}${NC}"
+echo -e "   Context: ${GREEN}$(pwd)${NC}"
+echo -e "   Dockerfile: ${GREEN}docker/Dockerfile${NC}"
+echo ""
+
+# Build the image with correct context
+# IMPORTANT: Context must be the repository root (.)
+# The Dockerfile is in docker/ subdirectory
+docker build \
+    --file docker/Dockerfile \
+    --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+    --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    .
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}=====================================${NC}"
+    echo -e "${GREEN}✅ Build completed successfully!${NC}"
+    echo -e "${GREEN}=====================================${NC}"
+    echo ""
+    echo -e "To run the container:"
+    echo -e "  ${GREEN}docker run -d -p 8000:8000 --name printernizer ${IMAGE_NAME}:${IMAGE_TAG}${NC}"
+    echo ""
+    echo -e "Or use docker-compose (recommended):"
+    echo -e "  ${GREEN}cd docker && docker-compose up -d${NC}"
+    echo ""
+else
+    echo ""
+    echo -e "${RED}=====================================${NC}"
+    echo -e "${RED}❌ Build failed!${NC}"
+    echo -e "${RED}=====================================${NC}"
+    exit 1
+fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,18 @@
 # Printernizer - Standalone Docker Deployment
 # Multi-stage build for optimized production container
+#
+# ⚠️  IMPORTANT: Build Context Requirements
+# This Dockerfile MUST be built with the repository root as the build context.
+#
+# Correct build commands:
+#   From repo root: docker build -f docker/Dockerfile -t printernizer .
+#   Using script:   ./build-docker.sh
+#   Using compose:  cd docker && docker-compose up -d
+#
+# ❌ INCORRECT (will fail with "entrypoint.sh not found"):
+#   cd docker && docker build -t printernizer .
+#
+# The build context must include: src/, frontend/, database_schema.sql, docker/
 
 # Stage 1: Builder
 FROM python:3.11-slim as builder

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,10 +11,32 @@ This directory contains everything needed to run Printernizer as a standalone Do
 
 ### Start Printernizer
 
+**Option 1: Using Docker Compose (Recommended)**
 ```bash
 # From project root
 cd docker
 docker-compose up -d
+```
+
+**Option 2: Using Build Script**
+```bash
+# From project root
+./build-docker.sh
+docker run -d -p 8000:8000 --name printernizer printernizer:latest
+```
+
+**Option 3: Manual Docker Build**
+```bash
+# IMPORTANT: Build from repository root with correct context
+cd /path/to/printernizer  # Must be repo root
+docker build -f docker/Dockerfile -t printernizer:latest .
+docker run -d -p 8000:8000 --name printernizer printernizer:latest
+```
+
+⚠️ **Common Error**: Do NOT build from inside the `docker/` directory like this:
+```bash
+cd docker
+docker build -t printernizer .  # ❌ WRONG - Will fail with "entrypoint.sh not found"
 ```
 
 Access the application:
@@ -152,6 +174,28 @@ docker-compose exec printernizer bash
 ```
 
 ## 🔍 Troubleshooting
+
+### "exec /app/entrypoint.sh: no such file or directory"
+
+This error occurs when the Docker image was built with an incorrect build context.
+
+**Solution:**
+```bash
+# Stop and remove any existing containers
+docker-compose down
+docker rm -f printernizer 2>/dev/null || true
+
+# Rebuild with correct context using docker-compose
+cd docker
+docker-compose build --no-cache
+docker-compose up -d
+
+# OR use the build script from repo root
+cd ..
+./build-docker.sh
+```
+
+**Root Cause**: The Dockerfile requires the repository root as the build context because it needs to access `src/`, `frontend/`, `database_schema.sql`, and `docker/entrypoint.sh`. Building from inside the `docker/` directory will fail.
 
 ### Container Won't Start
 

--- a/docker/TROUBLESHOOTING.md
+++ b/docker/TROUBLESHOOTING.md
@@ -1,0 +1,274 @@
+# Docker Troubleshooting Guide
+
+## Common Issues and Solutions
+
+### 1. "exec /app/entrypoint.sh: no such file or directory"
+
+**Symptoms:**
+- Container fails to start immediately after being created
+- Error appears in logs: `exec /app/entrypoint.sh: no such file or directory`
+- Container exits with status code 1
+
+**Root Cause:**
+The Docker image was built with an incorrect build context. The Dockerfile expects to be built from the repository root so it can access all required files:
+- `src/` (application source code)
+- `frontend/` (web interface)
+- `database_schema.sql` (database schema)
+- `docker/entrypoint.sh` (startup script)
+
+**Solution:**
+
+```bash
+# Step 1: Clean up any existing containers and images
+docker-compose down
+docker rm -f printernizer 2>/dev/null || true
+docker rmi printernizer:latest 2>/dev/null || true
+
+# Step 2: Rebuild correctly (choose one method)
+
+# Method A: Using docker-compose (recommended)
+cd docker
+docker-compose build --no-cache
+docker-compose up -d
+
+# Method B: Using build script
+cd ..  # Go to repo root
+./build-docker.sh
+
+# Method C: Manual build
+cd ..  # Go to repo root
+docker build -f docker/Dockerfile -t printernizer:latest .
+docker run -d -p 8000:8000 --name printernizer printernizer:latest
+```
+
+**Prevention:**
+- Always use `docker-compose` from the `docker/` directory, OR
+- Always use `./build-docker.sh` from the repository root, OR
+- When building manually, ensure the build context is the repository root
+
+**❌ WRONG (will cause the error):**
+```bash
+cd docker
+docker build -t printernizer .  # Context is docker/, not repo root
+```
+
+**✅ CORRECT:**
+```bash
+cd docker
+docker-compose up -d  # Compose handles the context correctly
+```
+
+---
+
+### 2. Container Won't Start (General)
+
+**Check logs first:**
+```bash
+docker-compose logs
+docker logs printernizer
+```
+
+**Rebuild container:**
+```bash
+docker-compose down
+docker-compose build --no-cache
+docker-compose up -d
+```
+
+---
+
+### 3. Database Issues
+
+**Symptom:** Database connection errors or corruption
+
+**Solution:**
+```bash
+# Backup existing data first (if any)
+docker run --rm -v printernizer_printernizer-data:/data -v $(pwd):/backup alpine tar czf /backup/printernizer-backup.tar.gz /data
+
+# Reset database (WARNING: deletes all data!)
+docker-compose down
+docker volume rm printernizer_printernizer-data
+docker-compose up -d
+```
+
+---
+
+### 4. Network Connectivity Issues
+
+**Symptom:** Can't connect to printers
+
+**Test connectivity:**
+```bash
+# Test from container
+docker-compose exec printernizer ping 192.168.1.100
+
+# Check container network
+docker network inspect printernizer_printernizer-network
+```
+
+**Solution for printer discovery:**
+If using printer auto-discovery (SSDP/mDNS), you may need host networking:
+
+Edit `docker-compose.yml`:
+```yaml
+services:
+  printernizer:
+    network_mode: host  # Enable this
+    # Comment out the 'networks' and 'ports' sections
+```
+
+---
+
+### 5. Permission Issues
+
+**Symptom:** Cannot write to database or files
+
+**Solution:**
+```bash
+# Check container logs for permission errors
+docker-compose logs | grep -i permission
+
+# Fix volume permissions
+docker-compose down
+docker volume rm printernizer_printernizer-data
+docker-compose up -d
+```
+
+---
+
+### 6. Port Already in Use
+
+**Symptom:** `Error starting userland proxy: listen tcp4 0.0.0.0:8000: bind: address already in use`
+
+**Solution:**
+```bash
+# Find what's using port 8000
+sudo lsof -i :8000
+# or
+sudo netstat -tulpn | grep :8000
+
+# Either stop the conflicting service or change the port
+# Edit docker-compose.yml:
+ports:
+  - "3000:8000"  # Use port 3000 instead
+```
+
+---
+
+### 7. Out of Memory Errors
+
+**Symptom:** Container killed or OOM errors in logs
+
+**Solution:**
+Increase memory limits in `docker-compose.yml`:
+```yaml
+deploy:
+  resources:
+    limits:
+      memory: 2G
+    reservations:
+      memory: 512M
+```
+
+---
+
+### 8. Slow Performance
+
+**Solutions:**
+
+1. **Database vacuum:**
+   ```bash
+   docker-compose exec printernizer sqlite3 /app/data/printernizer.db "VACUUM;"
+   ```
+
+2. **Clear cache:**
+   ```bash
+   docker-compose exec printernizer rm -rf /app/data/preview-cache/*
+   ```
+
+3. **Check resource usage:**
+   ```bash
+   docker stats printernizer
+   ```
+
+---
+
+## Health Checks
+
+### Check if container is healthy:
+```bash
+# Method 1: Docker inspect
+docker inspect printernizer | jq '.[0].State.Health'
+
+# Method 2: Health endpoint
+curl http://localhost:8000/api/v1/health
+
+# Expected response:
+{
+  "status": "healthy",
+  "version": "2.0.0",
+  "timestamp": "..."
+}
+```
+
+---
+
+## Debugging
+
+### Access container shell:
+```bash
+docker-compose exec printernizer bash
+```
+
+### Check file system:
+```bash
+# Verify entrypoint exists
+docker-compose exec printernizer ls -la /app/entrypoint.sh
+
+# Check application files
+docker-compose exec printernizer ls -la /app/src/
+
+# Check database
+docker-compose exec printernizer ls -la /app/data/
+```
+
+### View live logs:
+```bash
+# All logs
+docker-compose logs -f
+
+# Last 100 lines
+docker-compose logs --tail=100
+
+# Application logs only
+docker-compose exec printernizer tail -f /app/logs/app.log
+```
+
+---
+
+## Still Having Issues?
+
+1. **Check the main documentation:**
+   - [docker/README.md](README.md)
+   - [../README.md](../README.md)
+
+2. **Enable debug logging:**
+   Edit `docker-compose.yml`:
+   ```yaml
+   environment:
+     - LOG_LEVEL=debug
+   ```
+
+3. **Verify prerequisites:**
+   - Docker Engine 20.10+
+   - Docker Compose 2.0+
+   - Network access to printers
+   - Sufficient disk space (at least 2GB)
+
+4. **Report an issue:**
+   https://github.com/schmacka/printernizer/issues
+
+---
+
+**Last Updated:** 2025-11-11


### PR DESCRIPTION
Fixes issue where Docker container fails to start with error:
"exec /app/entrypoint.sh: no such file or directory"

Root Cause:
The Dockerfile requires the repository root as the build context to access
required files (src/, frontend/, database_schema.sql, docker/entrypoint.sh).
Building from the wrong directory causes the entrypoint.sh file to be missing
from the final image.

Changes:
- Added build-docker.sh script to ensure correct build context
- Updated docker/Dockerfile with clear build context requirements
- Enhanced docker/README.md with multiple build options and warnings
- Updated main README.md to reference the build script
- Created docker/TROUBLESHOOTING.md with comprehensive solutions

The build script validates all required files exist and ensures the
build context is always the repository root, preventing this error.

Users can now:
1. Use docker-compose (recommended): cd docker && docker-compose up -d
2. Use build script: ./build-docker.sh
3. Build manually with correct context: docker build -f docker/Dockerfile .

Resolves: Docker container startup failure
Related: Build context configuration, entrypoint.sh