### PR TITLE
fix: Correct drag-and-drop hover feedback for library file upload

### DIFF
--- a/frontend/css/library.css
+++ b/frontend/css/library.css
@@ -751,7 +751,7 @@
 /* ============ Drag and Drop Upload ============ */
 
 /* Drag-over highlight effect */
-#libraryGrid.drag-over {
+#libraryFilesGrid.drag-over {
     position: relative;
     border: 3px dashed #667eea;
     background-color: rgba(102, 126, 234, 0.05);
@@ -759,7 +759,7 @@
     transition: all 0.3s ease;
 }
 
-#libraryGrid.drag-over::before {
+#libraryFilesGrid.drag-over::before {
     content: '⬆️ Drop files here to upload';
     position: absolute;
     top: 50%;
@@ -887,12 +887,12 @@
 
 /* Dark theme support for upload UI */
 @media (prefers-color-scheme: dark) {
-    #libraryGrid.drag-over {
+    #libraryFilesGrid.drag-over {
         border-color: #818cf8;
         background-color: rgba(129, 140, 248, 0.05);
     }
 
-    #libraryGrid.drag-over::before {
+    #libraryFilesGrid.drag-over::before {
         color: #818cf8;
         background: rgba(30, 41, 59, 0.95);
     }

--- a/frontend/js/library.js
+++ b/frontend/js/library.js
@@ -1027,7 +1027,7 @@ class LibraryManager {
      * Setup drag-and-drop upload functionality
      */
     setupDragAndDrop() {
-        const libraryGrid = document.getElementById('libraryGrid');
+        const libraryGrid = document.getElementById('libraryFilesGrid');
         if (!libraryGrid) {
             console.warn('Library grid not found, drag-and-drop disabled');
             return;
@@ -1035,6 +1035,9 @@ class LibraryManager {
 
         // Allowed file extensions
         this.allowedExtensions = ['.3mf', '.stl', '.gcode', '.obj', '.ply'];
+
+        // Counter to track nested drag events
+        let dragCounter = 0;
 
         // Prevent default drag behaviors
         ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
@@ -1045,19 +1048,22 @@ class LibraryManager {
         });
 
         // Highlight drop zone when dragging over
-        libraryGrid.addEventListener('dragenter', () => {
+        libraryGrid.addEventListener('dragenter', (e) => {
+            dragCounter++;
             libraryGrid.classList.add('drag-over');
         });
 
         libraryGrid.addEventListener('dragleave', (e) => {
-            // Only remove highlight if leaving the grid entirely
-            if (e.target === libraryGrid) {
+            dragCounter--;
+            // Only remove highlight if we've left all nested elements
+            if (dragCounter === 0) {
                 libraryGrid.classList.remove('drag-over');
             }
         });
 
         // Handle file drop
         libraryGrid.addEventListener('drop', async (e) => {
+            dragCounter = 0;
             libraryGrid.classList.remove('drag-over');
 
             const files = Array.from(e.dataTransfer.files);
@@ -1066,7 +1072,7 @@ class LibraryManager {
             }
         });
 
-        console.log('Drag-and-drop upload enabled');
+        console.log('Drag-and-drop upload enabled for library grid');
     }
 
     /**

--- a/printernizer/frontend/css/library.css
+++ b/printernizer/frontend/css/library.css
@@ -751,7 +751,7 @@
 /* ============ Drag and Drop Upload ============ */
 
 /* Drag-over highlight effect */
-#libraryGrid.drag-over {
+#libraryFilesGrid.drag-over {
     position: relative;
     border: 3px dashed #667eea;
     background-color: rgba(102, 126, 234, 0.05);
@@ -759,7 +759,7 @@
     transition: all 0.3s ease;
 }
 
-#libraryGrid.drag-over::before {
+#libraryFilesGrid.drag-over::before {
     content: '⬆️ Drop files here to upload';
     position: absolute;
     top: 50%;
@@ -887,12 +887,12 @@
 
 /* Dark theme support for upload UI */
 @media (prefers-color-scheme: dark) {
-    #libraryGrid.drag-over {
+    #libraryFilesGrid.drag-over {
         border-color: #818cf8;
         background-color: rgba(129, 140, 248, 0.05);
     }
 
-    #libraryGrid.drag-over::before {
+    #libraryFilesGrid.drag-over::before {
         color: #818cf8;
         background: rgba(30, 41, 59, 0.95);
     }

--- a/printernizer/frontend/js/library.js
+++ b/printernizer/frontend/js/library.js
@@ -1027,7 +1027,7 @@ class LibraryManager {
      * Setup drag-and-drop upload functionality
      */
     setupDragAndDrop() {
-        const libraryGrid = document.getElementById('libraryGrid');
+        const libraryGrid = document.getElementById('libraryFilesGrid');
         if (!libraryGrid) {
             console.warn('Library grid not found, drag-and-drop disabled');
             return;
@@ -1035,6 +1035,9 @@ class LibraryManager {
 
         // Allowed file extensions
         this.allowedExtensions = ['.3mf', '.stl', '.gcode', '.obj', '.ply'];
+
+        // Counter to track nested drag events
+        let dragCounter = 0;
 
         // Prevent default drag behaviors
         ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
@@ -1045,19 +1048,22 @@ class LibraryManager {
         });
 
         // Highlight drop zone when dragging over
-        libraryGrid.addEventListener('dragenter', () => {
+        libraryGrid.addEventListener('dragenter', (e) => {
+            dragCounter++;
             libraryGrid.classList.add('drag-over');
         });
 
         libraryGrid.addEventListener('dragleave', (e) => {
-            // Only remove highlight if leaving the grid entirely
-            if (e.target === libraryGrid) {
+            dragCounter--;
+            // Only remove highlight if we've left all nested elements
+            if (dragCounter === 0) {
                 libraryGrid.classList.remove('drag-over');
             }
         });
 
         // Handle file drop
         libraryGrid.addEventListener('drop', async (e) => {
+            dragCounter = 0;
             libraryGrid.classList.remove('drag-over');
 
             const files = Array.from(e.dataTransfer.files);
@@ -1066,7 +1072,7 @@ class LibraryManager {
             }
         });
 
-        console.log('Drag-and-drop upload enabled');
+        console.log('Drag-and-drop upload enabled for library grid');
     }
 
     /**


### PR DESCRIPTION
The drag-and-drop feature was not showing visual feedback when hovering files
over the library grid due to an element ID mismatch.

Changes:
- Fixed element ID from 'libraryGrid' to 'libraryFilesGrid' in JavaScript
- Updated CSS selectors to match correct element ID (light and dark themes)
- Improved drag event handling with counter to properly track nested elements
- This ensures the hover state persists when dragging over child elements

The feature now correctly displays:
- Dashed border around the drop zone
- Centered "Drop files here to upload" message
- Smooth transitions and proper cleanup on drag leave/drop

Fixes issue where no visual change appeared when dragging files over Firefox.