### PR TITLE
chore(ci): Update CodeQL Action from v2 to v3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -331,7 +331,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
- Updated github/codeql-action/upload-sarif from @v2 to @v3
- Addresses deprecation warning for CodeQL Action v1/v2
- Ref: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/