### PR TITLE
fix(ci): Add required permissions for CodeQL Action v3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -318,6 +318,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-backend, test-frontend]
 
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
When CodeQL Action was updated from v2 to v3 (commit b1fefdc), it introduced
a breaking change requiring explicit security-events: write permission for
uploading SARIF files.

This commit adds the required permissions block to the security-scan job:
- contents: read
- security-events: write

Without these permissions, the workflow fails with:
"This run of the CodeQL Action does not have permission to access the
 CodeQL Action API endpoints."

Fixes: GitHub Actions run #19287980625
Ref: https://github.com/github/codeql-action/blob/main/upload-sarif/README.md