### PR TITLE
fix: Support Home Assistant ingress paths in frontend

### DIFF
--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -6,34 +6,34 @@
     <title>Printernizer Debug</title>
     
     <!-- Main CSS -->
-    <link rel="stylesheet" href="/static/css/main.css">
-    <link rel="stylesheet" href="/static/css/components.css">
-    <link rel="stylesheet" href="/static/css/dashboard.css">
-    
+    <link rel="stylesheet" href="static/css/main.css">
+    <link rel="stylesheet" href="static/css/components.css">
+    <link rel="stylesheet" href="static/css/dashboard.css">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    
+
     <!-- Favicon -->
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="static/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="static/images/favicon-16x16.png">
 </head>
 <body class="debug-page">
     <!-- Navigation -->
     <nav class="main-nav">
         <div class="nav-container">
             <div class="nav-brand">
-                <img src="/static/images/logo.png" alt="Printernizer Logo" class="nav-logo">
+                <img src="static/images/logo.png" alt="Printernizer Logo" class="nav-logo">
                 <h1 class="nav-title">Printernizer <span class="debug-badge">DEBUG</span></h1>
             </div>
-            
+
             <div class="nav-controls">
                 <button class="btn btn-primary" onclick="refreshDebugInfo()" title="Debug-Daten aktualisieren">
                     <span class="btn-icon">🔄</span>
                     Aktualisieren
                 </button>
-                <a href="/" class="btn btn-secondary">
+                <a href="#" id="dashboardLink" class="btn btn-secondary">
                     <span class="btn-icon">🏠</span>
                     Dashboard
                 </a>
@@ -128,12 +128,19 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/static/js/utils.js"></script>
-    <script src="/static/js/debug.js"></script>
-    
+    <script src="js/config.js"></script>
+    <script src="js/utils.js"></script>
+    <script src="js/debug.js"></script>
+
     <script>
         // Initialize debug page when DOM is loaded
         document.addEventListener('DOMContentLoaded', function() {
+            // Set dashboard link with ingress path support
+            const dashboardLink = document.getElementById('dashboardLink');
+            if (dashboardLink && typeof CONFIG !== 'undefined') {
+                dashboardLink.href = CONFIG.BASE_PATH ? `${CONFIG.BASE_PATH}/` : '/';
+            }
+
             debugManager.init();
         });
     </script>

--- a/frontend/js/camera.js
+++ b/frontend/js/camera.js
@@ -258,8 +258,8 @@ class CameraManager {
                 ${snapshots.map(snapshot => `
                     <div class="snapshot-item">
                         <div class="snapshot-preview">
-                            <img src="/api/v1/snapshots/${snapshot.id}/download" 
-                                 alt="Snapshot" 
+                            <img src="${CONFIG.BASE_PATH}/api/v1/snapshots/${snapshot.id}/download"
+                                 alt="Snapshot"
                                  onerror="this.src='data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjE1MCIgdmlld0JveD0iMCAwIDIwMCAxNTAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMTUwIiBmaWxsPSIjZjNmNGY2Ii8+CjxwYXRoIGQ9Im03NSA2MCA2IDAgMCAxIDEyIDAgNiA2IDAgMCAxIDAgMTIgNiA2IDAgMCAxLTEyIDAgNiA2IDAgMCAxIDAtMTJaTTk5IDkwbC0zNi0zNiA5LTkgMjcgMjcgNjMtNjMgOS05LTcyIDcyWiIgZmlsbD0iIzZiNzI4MCIvPgo8L3N2Zz4K';">
                         </div>
                         <div class="snapshot-info">
@@ -269,8 +269,8 @@ class CameraManager {
                             ${snapshot.notes ? `<div class="snapshot-notes">${escapeHtml(snapshot.notes)}</div>` : ''}
                         </div>
                         <div class="snapshot-actions">
-                            <a href="/api/v1/snapshots/${snapshot.id}/download" 
-                               class="btn btn-sm btn-secondary" 
+                            <a href="${CONFIG.BASE_PATH}/api/v1/snapshots/${snapshot.id}/download"
+                               class="btn btn-sm btn-secondary"
                                download="${snapshot.filename}"
                                title="Herunterladen">
                                 💾

--- a/frontend/js/library.js
+++ b/frontend/js/library.js
@@ -1136,7 +1136,7 @@ class LibraryManager {
 
         try {
             // Upload files
-            const response = await fetch('/api/v1/files/upload', {
+            const response = await fetch(`${CONFIG.BASE_PATH}/api/v1/files/upload`, {
                 method: 'POST',
                 body: formData
             });

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -472,7 +472,7 @@ function showFullThumbnail(fileId, filename) {
                 <button class="thumbnail-modal-close" onclick="this.parentElement.parentElement.parentElement.remove()">&times;</button>
             </div>
             <div class="thumbnail-modal-body">
-                <img src="/api/v1/files/${fileId}/thumbnail"
+                <img src="${CONFIG.BASE_PATH}/api/v1/files/${fileId}/thumbnail"
                      alt="Full size thumbnail"
                      class="full-thumbnail-image"
                      onerror="this.nextElementSibling.style.display='block'; this.style.display='none'">

--- a/frontend/js/materials.js
+++ b/frontend/js/materials.js
@@ -40,7 +40,7 @@ class MaterialsManager {
 
     async loadEnums() {
         try {
-            const response = await fetch('/api/v1/materials/types');
+            const response = await fetch(`${CONFIG.BASE_PATH}/api/v1/materials/types`);
             if (!response.ok) {
                 console.error('Failed to load material types: HTTP', response.status);
                 // Set default enums if API fails
@@ -161,7 +161,7 @@ class MaterialsManager {
 
     async updateStats() {
         try {
-            const response = await fetch('/api/v1/materials/stats');
+            const response = await fetch(`${CONFIG.BASE_PATH}/api/v1/materials/stats`);
             const stats = await response.json();
 
             // Update stat cards


### PR DESCRIPTION
Problem:
- Frontend worked via direct IP:port but failed via HA ingress
- Absolute URL paths (e.g., /api/endpoint) bypassed ingress proxy
- Static resources and navigation links used hardcoded absolute paths

Solution:
- Added BASE_PATH to CONFIG for detecting ingress path prefix
- Fixed hardcoded fetch() calls in materials.js (2), library.js (1)
- Fixed image/link paths in camera.js, main.js to use BASE_PATH
- Converted debug.html to use relative paths for CSS/images
- Made debug.html dashboard link dynamic using JavaScript

Changes:
- frontend/js/config.js: Added getBasePath() function and CONFIG.BASE_PATH
- frontend/js/materials.js: Fixed 2 hardcoded /api/v1/ fetch calls
- frontend/js/library.js: Fixed 1 hardcoded /api/v1/ fetch call
- frontend/js/camera.js: Fixed snapshot image and download links
- frontend/js/main.js: Fixed thumbnail image src
- frontend/debug.html: Converted to relative paths and dynamic dashboard link

Testing:
- Should work via HA ingress (/api/hassio_ingress/<token>/)
- Should still work via direct IP:port access
- All API calls and navigation now include correct base path