### PR TITLE
fix: Remove duplicate div tag in settings general tab

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1044,8 +1044,6 @@
                 <div class="settings-tab-content">
                     <!-- General Settings Tab -->
                     <div class="tab-pane active" id="general-tab">
-                    <!-- General Settings Tab -->
-                    <div class="tab-pane active" id="general-tab">
                         <div class="card settings-section">
                             <div class="card-header">
                                 <h3>⚙️ Allgemeine Einstellungen</h3>


### PR DESCRIPTION
The general-tab had a duplicate opening <div> tag which was causing
settings tabs to show empty content when clicked. This fix removes
the duplicate tag, restoring proper tab switching functionality.

Fixes issue where clicking on settings categories showed empty content.