### PR TITLE
feat: Add settings accessibility tests and fix tab switching

### DIFF
--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -49,25 +49,61 @@ class SettingsManager {
     switchTab(tabName) {
         console.log('Switching to tab:', tabName);
 
-        // Update tab buttons
-        document.querySelectorAll('.settings-tab').forEach(tab => {
-            tab.classList.remove('active');
-        });
-        const activeTab = document.querySelector(`.settings-tab[data-tab="${tabName}"]`);
-        if (activeTab) {
-            activeTab.classList.add('active');
-        }
+        try {
+            // Validate tab name
+            if (!tabName || typeof tabName !== 'string') {
+                console.error('Invalid tab name:', tabName);
+                return;
+            }
 
-        // Update tab content
-        document.querySelectorAll('.tab-pane').forEach(pane => {
-            pane.classList.remove('active');
-        });
-        const activePane = document.getElementById(`${tabName}-tab`);
-        if (activePane) {
-            activePane.classList.add('active');
-        }
+            // Update tab buttons - remove active from all tabs
+            const allTabs = document.querySelectorAll('.settings-tab');
+            console.log(`Found ${allTabs.length} tab buttons`);
+            allTabs.forEach(tab => {
+                tab.classList.remove('active');
+                tab.setAttribute('aria-selected', 'false');
+            });
 
-        this.currentTab = tabName;
+            // Add active to the clicked tab
+            const activeTab = document.querySelector(`.settings-tab[data-tab="${tabName}"]`);
+            if (activeTab) {
+                activeTab.classList.add('active');
+                activeTab.setAttribute('aria-selected', 'true');
+                console.log(`Activated tab button: ${tabName}`);
+            } else {
+                console.error(`Tab button not found for: ${tabName}`);
+                return;
+            }
+
+            // Update tab content - remove active from all panes
+            const allPanes = document.querySelectorAll('.tab-pane');
+            console.log(`Found ${allPanes.length} tab panes`);
+            allPanes.forEach(pane => {
+                pane.classList.remove('active');
+                pane.style.display = 'none';  // Explicitly set display none
+                pane.setAttribute('aria-hidden', 'true');
+            });
+
+            // Add active to the target pane
+            const activePane = document.getElementById(`${tabName}-tab`);
+            if (activePane) {
+                activePane.classList.add('active');
+                activePane.style.display = 'block';  // Explicitly set display block
+                activePane.setAttribute('aria-hidden', 'false');
+                console.log(`Activated tab pane: ${tabName}-tab`);
+            } else {
+                console.error(`Tab pane not found for: ${tabName}-tab`);
+                return;
+            }
+
+            // Update current tab tracking
+            this.currentTab = tabName;
+            console.log(`Successfully switched to tab: ${tabName}`);
+
+        } catch (error) {
+            console.error('Error in switchTab:', error);
+            showToast('error', 'Fehler', 'Tab konnte nicht gewechselt werden');
+        }
     }
 
     /**

--- a/printernizer/frontend/js/settings.js
+++ b/printernizer/frontend/js/settings.js
@@ -49,25 +49,61 @@ class SettingsManager {
     switchTab(tabName) {
         console.log('Switching to tab:', tabName);
 
-        // Update tab buttons
-        document.querySelectorAll('.settings-tab').forEach(tab => {
-            tab.classList.remove('active');
-        });
-        const activeTab = document.querySelector(`.settings-tab[data-tab="${tabName}"]`);
-        if (activeTab) {
-            activeTab.classList.add('active');
-        }
+        try {
+            // Validate tab name
+            if (!tabName || typeof tabName !== 'string') {
+                console.error('Invalid tab name:', tabName);
+                return;
+            }
 
-        // Update tab content
-        document.querySelectorAll('.tab-pane').forEach(pane => {
-            pane.classList.remove('active');
-        });
-        const activePane = document.getElementById(`${tabName}-tab`);
-        if (activePane) {
-            activePane.classList.add('active');
-        }
+            // Update tab buttons - remove active from all tabs
+            const allTabs = document.querySelectorAll('.settings-tab');
+            console.log(`Found ${allTabs.length} tab buttons`);
+            allTabs.forEach(tab => {
+                tab.classList.remove('active');
+                tab.setAttribute('aria-selected', 'false');
+            });
 
-        this.currentTab = tabName;
+            // Add active to the clicked tab
+            const activeTab = document.querySelector(`.settings-tab[data-tab="${tabName}"]`);
+            if (activeTab) {
+                activeTab.classList.add('active');
+                activeTab.setAttribute('aria-selected', 'true');
+                console.log(`Activated tab button: ${tabName}`);
+            } else {
+                console.error(`Tab button not found for: ${tabName}`);
+                return;
+            }
+
+            // Update tab content - remove active from all panes
+            const allPanes = document.querySelectorAll('.tab-pane');
+            console.log(`Found ${allPanes.length} tab panes`);
+            allPanes.forEach(pane => {
+                pane.classList.remove('active');
+                pane.style.display = 'none';  // Explicitly set display none
+                pane.setAttribute('aria-hidden', 'true');
+            });
+
+            // Add active to the target pane
+            const activePane = document.getElementById(`${tabName}-tab`);
+            if (activePane) {
+                activePane.classList.add('active');
+                activePane.style.display = 'block';  // Explicitly set display block
+                activePane.setAttribute('aria-hidden', 'false');
+                console.log(`Activated tab pane: ${tabName}-tab`);
+            } else {
+                console.error(`Tab pane not found for: ${tabName}-tab`);
+                return;
+            }
+
+            // Update current tab tracking
+            this.currentTab = tabName;
+            console.log(`Successfully switched to tab: ${tabName}`);
+
+        } catch (error) {
+            console.error('Error in switchTab:', error);
+            showToast('error', 'Fehler', 'Tab konnte nicht gewechselt werden');
+        }
     }
 
     /**

--- a/tests/backend/test_api_settings.py
+++ b/tests/backend/test_api_settings.py
@@ -1,0 +1,286 @@
+"""
+Test suite for Settings API endpoints
+Tests all settings-related API functionality including application settings,
+printer configurations, and watch folders.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(test_app):
+    """Test client fixture using test_app from conftest."""
+    return TestClient(test_app)
+
+
+class TestSettingsAPI:
+    """Test settings management API endpoints"""
+
+    def test_get_application_settings(self, client, test_app):
+        """Test GET /api/v1/settings/application - Get all application settings"""
+        from unittest.mock import Mock
+
+        # Mock the config service
+        mock_config_service = Mock()
+        mock_config_service.get_application_settings.return_value = {
+            'database_path': '/data/printernizer.db',
+            'host': '0.0.0.0',
+            'port': 8000,
+            'debug': False,
+            'environment': 'production',
+            'log_level': 'INFO',
+            'timezone': 'Europe/Berlin',
+            'currency': 'EUR',
+            'vat_rate': 19.0,
+            'downloads_path': '/data/downloads',
+            'max_file_size': 104857600,
+            'monitoring_interval': 5,
+            'connection_timeout': 10,
+            'cors_origins': ['*'],
+            'job_creation_auto_create': True,
+            'gcode_optimize_print_only': True,
+            'gcode_optimization_max_lines': 50000,
+            'gcode_render_max_lines': 10000,
+            'enable_upload': True,
+            'max_upload_size_mb': 100,
+            'allowed_upload_extensions': '.stl,.3mf,.gcode',
+            'library_enabled': True,
+            'library_path': '/data/library',
+            'library_auto_organize': True,
+            'library_auto_extract_metadata': True,
+            'library_auto_deduplicate': False,
+            'library_preserve_originals': True,
+            'library_checksum_algorithm': 'sha256',
+            'library_processing_workers': 2,
+            'library_search_enabled': True,
+            'library_search_min_length': 3,
+            'timelapse_enabled': False,
+            'timelapse_source_folder': '',
+            'timelapse_output_folder': '',
+            'timelapse_output_strategy': 'job',
+            'timelapse_auto_process_timeout': 300,
+            'timelapse_cleanup_age_days': 30,
+        }
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        response = client.get("/api/v1/settings/application")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify all required fields are present
+        required_fields = [
+            'database_path', 'host', 'port', 'debug', 'environment', 'log_level',
+            'timezone', 'currency', 'vat_rate', 'downloads_path', 'max_file_size',
+            'monitoring_interval', 'connection_timeout', 'cors_origins',
+            'job_creation_auto_create',
+            'gcode_optimize_print_only', 'gcode_optimization_max_lines', 'gcode_render_max_lines',
+            'enable_upload', 'max_upload_size_mb', 'allowed_upload_extensions',
+            'library_enabled', 'library_path', 'library_auto_organize',
+            'library_auto_extract_metadata', 'library_auto_deduplicate',
+            'library_preserve_originals', 'library_checksum_algorithm',
+            'library_processing_workers', 'library_search_enabled', 'library_search_min_length',
+            'timelapse_enabled', 'timelapse_source_folder', 'timelapse_output_folder',
+            'timelapse_output_strategy', 'timelapse_auto_process_timeout', 'timelapse_cleanup_age_days',
+        ]
+
+        for field in required_fields:
+            assert field in data, f"Missing required field: {field}"
+
+    def test_update_application_settings(self, client, test_app):
+        """Test PUT /api/v1/settings/application - Update application settings"""
+        from unittest.mock import Mock
+
+        mock_config_service = Mock()
+        mock_config_service.update_application_settings.return_value = True
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        update_data = {
+            'log_level': 'DEBUG',
+            'monitoring_interval': 10,
+            'vat_rate': 19.5,
+            'job_creation_auto_create': False,
+            'library_enabled': True,
+        }
+
+        response = client.put("/api/v1/settings/application", json=update_data)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['status'] == 'success'
+        assert 'updated_fields' in data
+        assert len(data['updated_fields']) == 5
+
+    def test_update_application_settings_no_changes(self, client, test_app):
+        """Test PUT /api/v1/settings/application with no changes"""
+        from unittest.mock import Mock
+
+        mock_config_service = Mock()
+        mock_config_service.update_application_settings.return_value = False
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        response = client.put("/api/v1/settings/application", json={})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['status'] == 'success'
+        assert data['updated_fields'] == []
+
+    def test_get_watch_folder_settings(self, client, test_app):
+        """Test GET /api/v1/settings/watch-folders - Get watch folder settings"""
+        from unittest.mock import Mock, AsyncMock
+
+        mock_config_service = Mock()
+        mock_config_service.get_watch_folder_settings = AsyncMock(return_value={
+            'watch_folders': ['/data/watch1', '/data/watch2'],
+            'enabled': True,
+            'recursive': False,
+            'supported_extensions': ['.stl', '.3mf', '.gcode']
+        })
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        response = client.get("/api/v1/settings/watch-folders")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert 'watch_folders' in data
+        assert 'enabled' in data
+        assert 'recursive' in data
+        assert 'supported_extensions' in data
+        assert len(data['watch_folders']) == 2
+
+
+class TestSettingsValidation:
+    """Test settings validation endpoints"""
+
+    def test_validate_downloads_path_success(self, client, test_app):
+        """Test POST /api/v1/settings/downloads-path/validate - Valid path"""
+        from unittest.mock import Mock
+
+        mock_config_service = Mock()
+        mock_config_service.validate_downloads_path.return_value = {
+            'valid': True,
+            'message': 'Path is valid and writable'
+        }
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        response = client.post("/api/v1/settings/downloads-path/validate?folder_path=/data/downloads")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['valid'] is True
+
+    def test_validate_library_path_success(self, client, test_app):
+        """Test POST /api/v1/settings/library-path/validate - Valid path"""
+        from unittest.mock import Mock
+
+        mock_config_service = Mock()
+        mock_config_service.validate_library_path.return_value = {
+            'valid': True,
+            'message': 'Path is valid and writable'
+        }
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        response = client.post("/api/v1/settings/library-path/validate?folder_path=/data/library")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['valid'] is True
+
+
+class TestSettingsAccessibility:
+    """Test that all settings fields are accessible and properly defined"""
+
+    def test_all_general_settings_accessible(self, client, test_app):
+        """Test that all general settings fields are accessible via API"""
+        from unittest.mock import Mock
+
+        mock_config_service = Mock()
+        mock_config_service.get_application_settings.return_value = {
+            'database_path': '/data/printernizer.db',
+            'host': '0.0.0.0',
+            'port': 8000,
+            'debug': False,
+            'environment': 'production',
+            'log_level': 'INFO',
+            'timezone': 'Europe/Berlin',
+            'currency': 'EUR',
+            'vat_rate': 19.0,
+            'downloads_path': '/data/downloads',
+            'max_file_size': 104857600,
+            'monitoring_interval': 5,
+            'connection_timeout': 10,
+            'cors_origins': ['*'],
+            'job_creation_auto_create': True,
+            'gcode_optimize_print_only': True,
+            'gcode_optimization_max_lines': 50000,
+            'gcode_render_max_lines': 10000,
+            'enable_upload': True,
+            'max_upload_size_mb': 100,
+            'allowed_upload_extensions': '.stl,.3mf,.gcode',
+            'library_enabled': True,
+            'library_path': '/data/library',
+            'library_auto_organize': True,
+            'library_auto_extract_metadata': True,
+            'library_auto_deduplicate': False,
+            'library_preserve_originals': True,
+            'library_checksum_algorithm': 'sha256',
+            'library_processing_workers': 2,
+            'library_search_enabled': True,
+            'library_search_min_length': 3,
+            'timelapse_enabled': False,
+            'timelapse_source_folder': '',
+            'timelapse_output_folder': '',
+            'timelapse_output_strategy': 'job',
+            'timelapse_auto_process_timeout': 300,
+            'timelapse_cleanup_age_days': 30,
+        }
+        test_app.dependency_overrides[test_app.state.get_config_service] = lambda: mock_config_service
+
+        response = client.get("/api/v1/settings/application")
+        assert response.status_code == 200
+
+        data = response.json()
+
+        # General settings
+        assert 'log_level' in data
+        assert 'monitoring_interval' in data
+        assert 'connection_timeout' in data
+        assert 'vat_rate' in data
+        assert 'timezone' in data
+        assert 'currency' in data
+
+        # Job creation settings
+        assert 'job_creation_auto_create' in data
+
+        # G-code settings
+        assert 'gcode_optimize_print_only' in data
+        assert 'gcode_optimization_max_lines' in data
+        assert 'gcode_render_max_lines' in data
+
+        # Library settings
+        assert 'library_enabled' in data
+        assert 'library_path' in data
+        assert 'library_auto_organize' in data
+        assert 'library_auto_extract_metadata' in data
+        assert 'library_auto_deduplicate' in data
+        assert 'library_preserve_originals' in data
+        assert 'library_checksum_algorithm' in data
+        assert 'library_processing_workers' in data
+        assert 'library_search_enabled' in data
+        assert 'library_search_min_length' in data
+
+        # File settings
+        assert 'downloads_path' in data
+        assert 'max_file_size' in data
+        assert 'enable_upload' in data
+        assert 'max_upload_size_mb' in data
+        assert 'allowed_upload_extensions' in data
+
+        # Timelapse settings
+        assert 'timelapse_enabled' in data
+        assert 'timelapse_source_folder' in data
+        assert 'timelapse_output_folder' in data
+        assert 'timelapse_output_strategy' in data
+        assert 'timelapse_auto_process_timeout' in data
+        assert 'timelapse_cleanup_age_days' in data

--- a/tests/e2e/pages/__init__.py
+++ b/tests/e2e/pages/__init__.py
@@ -3,10 +3,12 @@ from .dashboard_page import DashboardPage
 from .printers_page import PrintersPage
 from .jobs_page import JobsPage
 from .materials_page import MaterialsPage
+from .settings_page import SettingsPage
 
 __all__ = [
     "DashboardPage",
-    "PrintersPage", 
+    "PrintersPage",
     "JobsPage",
     "MaterialsPage",
+    "SettingsPage",
 ]

--- a/tests/e2e/pages/settings_page.py
+++ b/tests/e2e/pages/settings_page.py
@@ -1,0 +1,188 @@
+"""
+Page Object Model for Printernizer Settings Page
+"""
+from playwright.sync_api import Page, expect
+from typing import Optional, List
+
+
+class SettingsPage:
+    """Page object for the settings page"""
+
+    def __init__(self, page: Page):
+        self.page = page
+
+        # Tab selectors
+        self.settings_tabs_selector = ".settings-tab"
+        self.active_tab_selector = ".settings-tab.active"
+        self.tab_content_selector = ".tab-pane"
+        self.active_tab_content_selector = ".tab-pane.active"
+
+        # Tab button selectors
+        self.general_tab_selector = ".settings-tab[data-tab='general']"
+        self.jobs_tab_selector = ".settings-tab[data-tab='jobs']"
+        self.library_tab_selector = ".settings-tab[data-tab='library']"
+        self.files_tab_selector = ".settings-tab[data-tab='files']"
+        self.timelapse_tab_selector = ".settings-tab[data-tab='timelapse']"
+        self.watch_tab_selector = ".settings-tab[data-tab='watch']"
+        self.system_tab_selector = ".settings-tab[data-tab='system']"
+
+        # Tab pane selectors
+        self.general_pane_selector = "#general-tab"
+        self.jobs_pane_selector = "#jobs-tab"
+        self.library_pane_selector = "#library-tab"
+        self.files_pane_selector = "#files-tab"
+        self.timelapse_pane_selector = "#timelapse-tab"
+        self.watch_pane_selector = "#watch-tab"
+        self.system_pane_selector = "#system-tab"
+
+        # Form selectors
+        self.settings_form_selector = "#applicationSettingsForm"
+        self.save_button_selector = "button[onclick='saveSettings()']"
+
+        # Settings field selectors (General)
+        self.log_level_selector = "#logLevel"
+        self.monitoring_interval_selector = "#monitoringInterval"
+        self.connection_timeout_selector = "#connectionTimeout"
+        self.vat_rate_selector = "#vatRate"
+
+        # Settings field selectors (Jobs & G-Code)
+        self.job_auto_create_selector = "#jobCreationAutoCreate"
+        self.gcode_optimize_selector = "#gcodeOptimizePrintOnly"
+        self.gcode_max_lines_selector = "#gcodeOptimizationMaxLines"
+        self.gcode_render_max_lines_selector = "#gcodeRenderMaxLines"
+
+        # Settings field selectors (Library)
+        self.library_enabled_selector = "#libraryEnabled"
+        self.library_path_selector = "#libraryPath"
+        self.library_auto_organize_selector = "#libraryAutoOrganize"
+        self.library_auto_extract_metadata_selector = "#libraryAutoExtractMetadata"
+        self.library_auto_deduplicate_selector = "#libraryAutoDeduplicate"
+        self.library_preserve_originals_selector = "#libraryPreserveOriginals"
+        self.library_checksum_algorithm_selector = "#libraryChecksumAlgorithm"
+        self.library_processing_workers_selector = "#libraryProcessingWorkers"
+        self.library_search_enabled_selector = "#librarySearchEnabled"
+        self.library_search_min_length_selector = "#librarySearchMinLength"
+
+        # Settings field selectors (Files)
+        self.downloads_path_selector = "#downloadsPath"
+        self.max_file_size_selector = "#maxFileSize"
+        self.enable_upload_selector = "#enableUpload"
+        self.max_upload_size_selector = "#maxUploadSizeMb"
+        self.allowed_upload_extensions_selector = "#allowedUploadExtensions"
+
+        # Settings field selectors (Timelapse)
+        self.timelapse_enabled_selector = "#timelapseEnabled"
+        self.timelapse_source_folder_selector = "#timelapseSourceFolder"
+        self.timelapse_output_folder_selector = "#timelapseOutputFolder"
+        self.timelapse_output_strategy_selector = "#timelapseOutputStrategy"
+        self.timelapse_auto_process_timeout_selector = "#timelapseAutoProcessTimeout"
+        self.timelapse_cleanup_age_days_selector = "#timelapseCleanupAgeDays"
+
+    def navigate(self, base_url: str):
+        """Navigate to the settings page"""
+        # Settings is in the index.html as a tab/section
+        self.page.goto(base_url)
+        self.page.wait_for_load_state("networkidle")
+
+        # Click on settings navigation if it exists
+        settings_nav = self.page.locator("a[href*='settings'], nav a:has-text('Settings'), nav a:has-text('Einstellungen')")
+        if settings_nav.count() > 0:
+            settings_nav.first.click()
+            self.page.wait_for_load_state("networkidle")
+
+    def is_loaded(self) -> bool:
+        """Check if the settings page is loaded"""
+        try:
+            self.page.wait_for_selector(self.settings_tabs_selector, timeout=5000)
+            return True
+        except:
+            return False
+
+    def get_all_tabs(self) -> List[str]:
+        """Get all available tab names"""
+        tabs = []
+        tab_elements = self.page.locator(self.settings_tabs_selector).all()
+        for tab in tab_elements:
+            tab_name = tab.get_attribute("data-tab")
+            if tab_name:
+                tabs.append(tab_name)
+        return tabs
+
+    def get_active_tab(self) -> Optional[str]:
+        """Get the currently active tab name"""
+        active_tab = self.page.locator(self.active_tab_selector).first
+        if active_tab.count() > 0:
+            return active_tab.get_attribute("data-tab")
+        return None
+
+    def click_tab(self, tab_name: str):
+        """Click on a specific tab"""
+        tab_selector = f".settings-tab[data-tab='{tab_name}']"
+        self.page.click(tab_selector)
+        self.page.wait_for_timeout(300)  # Wait for tab transition
+
+    def is_tab_visible(self, tab_name: str) -> bool:
+        """Check if a tab is visible"""
+        tab_selector = f".settings-tab[data-tab='{tab_name}']"
+        return self.page.locator(tab_selector).is_visible()
+
+    def is_tab_active(self, tab_name: str) -> bool:
+        """Check if a specific tab is active"""
+        tab_selector = f".settings-tab[data-tab='{tab_name}'].active"
+        return self.page.locator(tab_selector).count() > 0
+
+    def is_tab_pane_visible(self, tab_name: str) -> bool:
+        """Check if a tab pane is visible"""
+        pane_selector = f"#{tab_name}-tab.active"
+        return self.page.locator(pane_selector).is_visible()
+
+    def wait_for_tab_to_load(self, tab_name: str, timeout: int = 5000):
+        """Wait for a specific tab pane to be visible"""
+        pane_selector = f"#{tab_name}-tab.active"
+        self.page.wait_for_selector(pane_selector, timeout=timeout)
+
+    def is_setting_field_visible(self, field_selector: str) -> bool:
+        """Check if a specific setting field is visible"""
+        return self.page.locator(field_selector).is_visible()
+
+    def get_setting_value(self, field_selector: str) -> str:
+        """Get the value of a setting field"""
+        element = self.page.locator(field_selector).first
+        input_type = element.get_attribute("type")
+
+        if input_type == "checkbox":
+            return str(element.is_checked())
+        else:
+            return element.input_value()
+
+    def set_setting_value(self, field_selector: str, value):
+        """Set the value of a setting field"""
+        element = self.page.locator(field_selector).first
+        input_type = element.get_attribute("type")
+
+        if input_type == "checkbox":
+            if value:
+                element.check()
+            else:
+                element.uncheck()
+        else:
+            element.fill(str(value))
+
+    def click_save_button(self):
+        """Click the save settings button"""
+        self.page.click(self.save_button_selector)
+        self.page.wait_for_timeout(500)  # Wait for save operation
+
+    def expect_tab_is_active(self, tab_name: str):
+        """Assert that a tab is active"""
+        tab_selector = f".settings-tab[data-tab='{tab_name}'].active"
+        expect(self.page.locator(tab_selector)).to_be_visible()
+
+    def expect_tab_pane_is_visible(self, tab_name: str):
+        """Assert that a tab pane is visible"""
+        pane_selector = f"#{tab_name}-tab.active"
+        expect(self.page.locator(pane_selector)).to_be_visible()
+
+    def expect_setting_field_is_visible(self, field_selector: str):
+        """Assert that a setting field is visible"""
+        expect(self.page.locator(field_selector)).to_be_visible()

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -1,0 +1,278 @@
+"""
+E2E tests for Printernizer Settings Page
+Tests settings accessibility and tab switching functionality
+"""
+import pytest
+from playwright.sync_api import Page, expect
+from tests.e2e.pages import SettingsPage
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_settings_page_loads(app_page: Page, base_url: str):
+    """Test that the settings page loads successfully"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    assert settings.is_loaded(), "Settings page should load successfully"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_all_settings_tabs_are_visible(app_page: Page, base_url: str):
+    """Test that all settings tabs are visible"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Get all tabs
+    tabs = settings.get_all_tabs()
+
+    # Verify all expected tabs are present
+    expected_tabs = ['general', 'jobs', 'library', 'files', 'timelapse', 'watch', 'system']
+    for tab in expected_tabs:
+        assert tab in tabs, f"Tab '{tab}' should be present in settings"
+        assert settings.is_tab_visible(tab), f"Tab '{tab}' should be visible"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_settings_tab_switching_general_to_jobs(app_page: Page, base_url: str):
+    """Test switching from general tab to jobs tab"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Verify general tab is active by default
+    assert settings.is_tab_active('general'), "General tab should be active by default"
+    assert settings.is_tab_pane_visible('general'), "General pane should be visible by default"
+
+    # Click on jobs tab
+    settings.click_tab('jobs')
+
+    # Verify jobs tab is now active
+    assert settings.is_tab_active('jobs'), "Jobs tab should be active after clicking"
+    assert settings.is_tab_pane_visible('jobs'), "Jobs pane should be visible after clicking"
+
+    # Verify general tab is no longer active
+    assert not settings.is_tab_active('general'), "General tab should not be active after switching"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_settings_tab_switching_all_tabs(app_page: Page, base_url: str):
+    """Test switching between all settings tabs"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    tabs_to_test = ['general', 'jobs', 'library', 'files', 'timelapse', 'watch', 'system']
+
+    for tab in tabs_to_test:
+        # Click on tab
+        settings.click_tab(tab)
+
+        # Verify tab is active
+        assert settings.is_tab_active(tab), f"Tab '{tab}' should be active after clicking"
+
+        # Verify tab pane is visible
+        assert settings.is_tab_pane_visible(tab), f"Tab pane '{tab}' should be visible after clicking"
+
+        # Verify only one tab is active at a time
+        active_tabs = app_page.locator(".settings-tab.active").count()
+        assert active_tabs == 1, f"Only one tab should be active at a time, found {active_tabs}"
+
+        # Verify only one tab pane is visible at a time
+        active_panes = app_page.locator(".tab-pane.active").count()
+        assert active_panes == 1, f"Only one tab pane should be visible at a time, found {active_panes}"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_general_settings_fields_are_accessible(app_page: Page, base_url: str):
+    """Test that all general settings fields are accessible"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Click on general tab
+    settings.click_tab('general')
+
+    # Verify general settings fields are visible
+    general_fields = [
+        settings.log_level_selector,
+        settings.monitoring_interval_selector,
+        settings.connection_timeout_selector,
+        settings.vat_rate_selector,
+    ]
+
+    for field in general_fields:
+        assert settings.is_setting_field_visible(field), f"Field {field} should be visible in general tab"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_jobs_settings_fields_are_accessible(app_page: Page, base_url: str):
+    """Test that all jobs & g-code settings fields are accessible"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Click on jobs tab
+    settings.click_tab('jobs')
+
+    # Verify jobs settings fields are visible
+    jobs_fields = [
+        settings.job_auto_create_selector,
+        settings.gcode_optimize_selector,
+        settings.gcode_max_lines_selector,
+        settings.gcode_render_max_lines_selector,
+    ]
+
+    for field in jobs_fields:
+        assert settings.is_setting_field_visible(field), f"Field {field} should be visible in jobs tab"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_library_settings_fields_are_accessible(app_page: Page, base_url: str):
+    """Test that all library settings fields are accessible"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Click on library tab
+    settings.click_tab('library')
+
+    # Verify library settings fields are visible
+    library_fields = [
+        settings.library_enabled_selector,
+        settings.library_path_selector,
+        settings.library_auto_organize_selector,
+        settings.library_auto_extract_metadata_selector,
+        settings.library_auto_deduplicate_selector,
+        settings.library_preserve_originals_selector,
+        settings.library_checksum_algorithm_selector,
+        settings.library_processing_workers_selector,
+        settings.library_search_enabled_selector,
+        settings.library_search_min_length_selector,
+    ]
+
+    for field in library_fields:
+        assert settings.is_setting_field_visible(field), f"Field {field} should be visible in library tab"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_files_settings_fields_are_accessible(app_page: Page, base_url: str):
+    """Test that all file settings fields are accessible"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Click on files tab
+    settings.click_tab('files')
+
+    # Verify file settings fields are visible
+    files_fields = [
+        settings.downloads_path_selector,
+        settings.max_file_size_selector,
+        settings.enable_upload_selector,
+        settings.max_upload_size_selector,
+        settings.allowed_upload_extensions_selector,
+    ]
+
+    for field in files_fields:
+        assert settings.is_setting_field_visible(field), f"Field {field} should be visible in files tab"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_timelapse_settings_fields_are_accessible(app_page: Page, base_url: str):
+    """Test that all timelapse settings fields are accessible"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Click on timelapse tab
+    settings.click_tab('timelapse')
+
+    # Verify timelapse settings fields are visible
+    timelapse_fields = [
+        settings.timelapse_enabled_selector,
+        settings.timelapse_source_folder_selector,
+        settings.timelapse_output_folder_selector,
+        settings.timelapse_output_strategy_selector,
+        settings.timelapse_auto_process_timeout_selector,
+        settings.timelapse_cleanup_age_days_selector,
+    ]
+
+    for field in timelapse_fields:
+        assert settings.is_setting_field_visible(field), f"Field {field} should be visible in timelapse tab"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_settings_form_exists(app_page: Page, base_url: str):
+    """Test that the settings form exists"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Verify form exists
+    form = app_page.locator(settings.settings_form_selector)
+    expect(form).to_be_visible()
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_settings_save_button_exists(app_page: Page, base_url: str):
+    """Test that the save button exists"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Verify save button exists
+    save_button = app_page.locator(settings.save_button_selector)
+    expect(save_button).to_be_visible()
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_tab_switching_preserves_active_state(app_page: Page, base_url: str):
+    """Test that switching tabs properly updates active states"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Start at general tab
+    settings.click_tab('general')
+    app_page.wait_for_timeout(500)
+
+    # Switch to library tab
+    settings.click_tab('library')
+    app_page.wait_for_timeout(500)
+
+    # Verify library tab is active and general is not
+    settings.expect_tab_is_active('library')
+    settings.expect_tab_pane_is_visible('library')
+
+    # General tab should not be active
+    assert not settings.is_tab_active('general'), "General tab should not be active"
+    assert not settings.is_tab_pane_visible('general'), "General pane should not be visible"
+
+
+@pytest.mark.e2e
+@pytest.mark.playwright
+def test_rapid_tab_switching(app_page: Page, base_url: str):
+    """Test rapid tab switching to ensure no race conditions"""
+    settings = SettingsPage(app_page)
+    settings.navigate(base_url)
+
+    # Rapidly switch between tabs
+    tabs = ['general', 'jobs', 'library', 'files', 'timelapse']
+
+    for i in range(3):  # Do 3 rounds of rapid switching
+        for tab in tabs:
+            settings.click_tab(tab)
+            app_page.wait_for_timeout(100)  # Minimal wait
+
+    # After rapid switching, verify last tab is active
+    final_tab = tabs[-1]
+    app_page.wait_for_timeout(500)  # Wait for any animations to complete
+
+    assert settings.is_tab_active(final_tab), f"Final tab '{final_tab}' should be active after rapid switching"
+    assert settings.is_tab_pane_visible(final_tab), f"Final pane '{final_tab}' should be visible after rapid switching"
+
+    # Verify only one tab is active
+    active_tabs = app_page.locator(".settings-tab.active").count()
+    assert active_tabs == 1, f"Only one tab should be active after rapid switching, found {active_tabs}"

--- a/verify_tab_switching.html
+++ b/verify_tab_switching.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Settings Tab Switching Test</title>
+    <style>
+        .settings-tab {
+            padding: 10px;
+            margin: 5px;
+            border: 1px solid #ccc;
+            cursor: pointer;
+            display: inline-block;
+        }
+        .settings-tab.active {
+            background: #3b82f6;
+            color: white;
+            font-weight: bold;
+        }
+        .tab-pane {
+            display: none;
+            padding: 20px;
+            border: 1px solid #ccc;
+            margin-top: 10px;
+        }
+        .tab-pane.active {
+            display: block;
+        }
+        #test-results {
+            margin-top: 20px;
+            padding: 10px;
+            background: #f0f0f0;
+        }
+        .pass { color: green; font-weight: bold; }
+        .fail { color: red; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Settings Tab Switching Test</h1>
+
+    <div class="settings-tabs">
+        <button class="settings-tab active" data-tab="general" onclick="switchTab('general')">General</button>
+        <button class="settings-tab" data-tab="jobs" onclick="switchTab('jobs')">Jobs</button>
+        <button class="settings-tab" data-tab="library" onclick="switchTab('library')">Library</button>
+    </div>
+
+    <div class="settings-tab-content">
+        <div class="tab-pane active" id="general-tab">
+            <h2>General Settings</h2>
+            <p>This is the general settings content.</p>
+        </div>
+        <div class="tab-pane" id="jobs-tab">
+            <h2>Jobs Settings</h2>
+            <p>This is the jobs settings content.</p>
+        </div>
+        <div class="tab-pane" id="library-tab">
+            <h2>Library Settings</h2>
+            <p>This is the library settings content.</p>
+        </div>
+    </div>
+
+    <div id="test-results">
+        <h3>Test Results:</h3>
+        <div id="results"></div>
+    </div>
+
+    <button onclick="runTests()" style="margin-top: 20px; padding: 10px 20px; font-size: 16px;">Run Automated Tests</button>
+
+    <script>
+        function switchTab(tabName) {
+            console.log('Switching to tab:', tabName);
+
+            try {
+                // Validate tab name
+                if (!tabName || typeof tabName !== 'string') {
+                    console.error('Invalid tab name:', tabName);
+                    return;
+                }
+
+                // Update tab buttons - remove active from all tabs
+                const allTabs = document.querySelectorAll('.settings-tab');
+                console.log(`Found ${allTabs.length} tab buttons`);
+                allTabs.forEach(tab => {
+                    tab.classList.remove('active');
+                    tab.setAttribute('aria-selected', 'false');
+                });
+
+                // Add active to the clicked tab
+                const activeTab = document.querySelector(`.settings-tab[data-tab="${tabName}"]`);
+                if (activeTab) {
+                    activeTab.classList.add('active');
+                    activeTab.setAttribute('aria-selected', 'true');
+                    console.log(`Activated tab button: ${tabName}`);
+                } else {
+                    console.error(`Tab button not found for: ${tabName}`);
+                    return;
+                }
+
+                // Update tab content - remove active from all panes
+                const allPanes = document.querySelectorAll('.tab-pane');
+                console.log(`Found ${allPanes.length} tab panes`);
+                allPanes.forEach(pane => {
+                    pane.classList.remove('active');
+                    pane.style.display = 'none';  // Explicitly set display none
+                    pane.setAttribute('aria-hidden', 'true');
+                });
+
+                // Add active to the target pane
+                const activePane = document.getElementById(`${tabName}-tab`);
+                if (activePane) {
+                    activePane.classList.add('active');
+                    activePane.style.display = 'block';  // Explicitly set display block
+                    activePane.setAttribute('aria-hidden', 'false');
+                    console.log(`Activated tab pane: ${tabName}-tab`);
+                } else {
+                    console.error(`Tab pane not found for: ${tabName}-tab`);
+                    return;
+                }
+
+                console.log(`Successfully switched to tab: ${tabName}`);
+
+            } catch (error) {
+                console.error('Error in switchTab:', error);
+            }
+        }
+
+        function runTests() {
+            const results = [];
+            const resultsDiv = document.getElementById('results');
+            resultsDiv.innerHTML = '';
+
+            // Test 1: Switch to jobs tab
+            switchTab('jobs');
+            setTimeout(() => {
+                const jobsTabActive = document.querySelector('.settings-tab[data-tab="jobs"]').classList.contains('active');
+                const jobsPaneVisible = document.getElementById('jobs-tab').classList.contains('active');
+                const generalPaneHidden = !document.getElementById('general-tab').classList.contains('active');
+
+                const test1Pass = jobsTabActive && jobsPaneVisible && generalPaneHidden;
+                results.push({
+                    name: 'Test 1: Switch to jobs tab',
+                    pass: test1Pass,
+                    details: `Tab active: ${jobsTabActive}, Pane visible: ${jobsPaneVisible}, General hidden: ${generalPaneHidden}`
+                });
+
+                // Test 2: Switch to library tab
+                switchTab('library');
+                setTimeout(() => {
+                    const libraryTabActive = document.querySelector('.settings-tab[data-tab="library"]').classList.contains('active');
+                    const libraryPaneVisible = document.getElementById('library-tab').classList.contains('active');
+                    const jobsPaneHidden = !document.getElementById('jobs-tab').classList.contains('active');
+
+                    const test2Pass = libraryTabActive && libraryPaneVisible && jobsPaneHidden;
+                    results.push({
+                        name: 'Test 2: Switch to library tab',
+                        pass: test2Pass,
+                        details: `Tab active: ${libraryTabActive}, Pane visible: ${libraryPaneVisible}, Jobs hidden: ${jobsPaneHidden}`
+                    });
+
+                    // Test 3: Switch back to general tab
+                    switchTab('general');
+                    setTimeout(() => {
+                        const generalTabActive = document.querySelector('.settings-tab[data-tab="general"]').classList.contains('active');
+                        const generalPaneVisible = document.getElementById('general-tab').classList.contains('active');
+                        const libraryPaneHidden = !document.getElementById('library-tab').classList.contains('active');
+
+                        const test3Pass = generalTabActive && generalPaneVisible && libraryPaneHidden;
+                        results.push({
+                            name: 'Test 3: Switch back to general tab',
+                            pass: test3Pass,
+                            details: `Tab active: ${generalTabActive}, Pane visible: ${generalPaneVisible}, Library hidden: ${libraryPaneHidden}`
+                        });
+
+                        // Display all results
+                        results.forEach(result => {
+                            const div = document.createElement('div');
+                            div.innerHTML = `
+                                <p class="${result.pass ? 'pass' : 'fail'}">
+                                    ${result.pass ? '✓' : '✗'} ${result.name}: ${result.pass ? 'PASS' : 'FAIL'}
+                                </p>
+                                <p style="margin-left: 20px; font-size: 12px;">${result.details}</p>
+                            `;
+                            resultsDiv.appendChild(div);
+                        });
+
+                        const allPass = results.every(r => r.pass);
+                        const summary = document.createElement('div');
+                        summary.innerHTML = `<h4 class="${allPass ? 'pass' : 'fail'}">Overall: ${allPass ? 'ALL TESTS PASSED' : 'SOME TESTS FAILED'}</h4>`;
+                        resultsDiv.appendChild(summary);
+
+                    }, 500);
+                }, 500);
+            }, 500);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add comprehensive tests for settings page:
- Backend API tests for settings endpoints (test_api_settings.py)
- E2E tests for settings page accessibility and tab switching
- Settings page object model for E2E testing
- Standalone verification test (verify_tab_switching.html)

Fix settings tab switching functionality:
- Add explicit display style setting to ensure tabs switch properly
- Add input validation and error handling
- Add ARIA attributes for accessibility
- Add detailed console logging for debugging
- Add try-catch error handling

The tab switching now explicitly sets pane.style.display to override
any CSS conflicts that might prevent proper tab switching.

Closes: Settings tab switching issue