### PR TITLE
fix: Update database schema path in test configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def temp_database():
     temp_db.close()
 
     # Read schema file and create database
-    schema_path = os.path.join(os.path.dirname(__file__), '..', 'database_schema.sql')
+    schema_path = os.path.join(os.path.dirname(__file__), '..', 'assets', 'database', 'schema.sql')
     with open(schema_path, 'r', encoding='utf-8') as f:
         schema_sql = f.read()
 


### PR DESCRIPTION
After the project cleanup (commit bba05bc), the database schema file
was moved from root to assets/database/schema.sql, but the test
fixture in tests/conftest.py was not updated to reflect this change.

This caused all database-dependent tests to fail with:
FileNotFoundError: [Errno 2] No such file or directory:
'/home/user/printernizer/tests/../database_schema.sql'

Changes:
- Updated schema_path in tests/conftest.py temp_database fixture
- Changed from '../database_schema.sql' to '../assets/database/schema.sql'

Result: 17 of 18 database tests now pass (1 unrelated failure due to
missing pytz dependency)