### PR TITLE
feat: Add settings edit buttons to page headers with modal overlay

### DIFF
--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -92,6 +92,98 @@
     background: var(--gray-50);
 }
 
+/* Settings Modal - Large */
+.settings-modal .modal-content {
+    max-width: 900px;
+    max-height: 85vh;
+}
+
+.modal-large {
+    max-width: 900px !important;
+}
+
+.settings-modal-title {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+    flex: 1;
+}
+
+.modal-header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+}
+
+.modal-tab-selector {
+    padding: var(--spacing-2) var(--spacing-3);
+    border: 1px solid var(--gray-300);
+    border-radius: var(--radius-md);
+    background: var(--white);
+    font-size: var(--font-size-sm);
+    color: var(--gray-700);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.modal-tab-selector:hover {
+    border-color: var(--primary-color);
+}
+
+.modal-tab-selector:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.settings-modal-body {
+    padding: var(--spacing-4);
+    max-height: calc(85vh - 180px);
+    overflow-y: auto;
+}
+
+/* Breadcrumb Components */
+.settings-breadcrumb {
+    padding: var(--spacing-3) var(--spacing-6);
+    background: var(--gray-50);
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.breadcrumb-back {
+    background: none;
+    border: none;
+    color: var(--primary-color);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    padding: var(--spacing-2) var(--spacing-3);
+    border-radius: var(--radius-md);
+    transition: all 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-2);
+}
+
+.breadcrumb-back:hover {
+    background: var(--primary-color);
+    color: var(--white);
+}
+
+.breadcrumb-separator {
+    color: var(--gray-400);
+    margin: 0 var(--spacing-2);
+}
+
+/* Breadcrumb in modal title */
+.settings-modal-title .breadcrumb-back {
+    font-size: var(--font-size-sm);
+    padding: var(--spacing-1) var(--spacing-2);
+}
+
+.settings-modal-title .breadcrumb-separator {
+    font-size: var(--font-size-sm);
+}
+
 /* Form Components */
 .printer-specific-fields {
     border: 1px solid var(--gray-200);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -296,6 +296,10 @@
                             <option value="">Alle Drucker</option>
                         </select>
                     </div>
+                    <button class="btn btn-secondary btn-sm" onclick="openPageSettings('jobs', 'Druckaufträge')">
+                        <span class="btn-icon">⚙️</span>
+                        Einstellungen
+                    </button>
                     <button class="btn btn-secondary" onclick="refreshJobs()">
                         <span class="btn-icon">🔄</span>
                         Aktualisieren
@@ -356,6 +360,10 @@
                             <span>Nur verknüpfte</span>
                         </label>
                     </div>
+                    <button class="btn btn-secondary btn-sm" onclick="openPageSettings('timelapse', 'Zeitraffer-Videos')">
+                        <span class="btn-icon">⚙️</span>
+                        Einstellungen
+                    </button>
                     <button class="btn btn-secondary" onclick="refreshTimelapses()">
                         <span class="btn-icon">🔄</span>
                         Aktualisieren
@@ -436,6 +444,10 @@
                             <option value="">Alle Drucker</option>
                         </select>
                     </div>
+                    <button class="btn btn-secondary btn-sm" onclick="openPageSettings('files', 'Drucker-Dateien')">
+                        <span class="btn-icon">⚙️</span>
+                        Einstellungen
+                    </button>
                     <button class="btn btn-secondary" onclick="refreshFiles()">
                         <span class="btn-icon">🔄</span>
                         Aktualisieren
@@ -524,6 +536,10 @@
                                     aria-label="Suche löschen">✕</button>
                         </div>
                     </div>
+                    <button class="btn btn-secondary btn-sm" onclick="openPageSettings('library', 'Bibliothek')">
+                        <span class="btn-icon">⚙️</span>
+                        Einstellungen
+                    </button>
                     <button class="btn btn-primary" onclick="triggerFileUpload()">
                         <span class="btn-icon">📤</span>
                         Hochladen
@@ -981,6 +997,13 @@
 
         <!-- Settings Page -->
         <div id="settings" class="page">
+            <!-- Settings Breadcrumb -->
+            <div id="settingsBreadcrumb" class="settings-breadcrumb" style="display: none;">
+                <button class="breadcrumb-back" onclick="navigateBackFromSettings()">
+                    ← Zurück
+                </button>
+            </div>
+
             <div class="page-header">
                 <h1>⚙️ Einstellungen</h1>
                 <div class="header-actions">
@@ -2374,6 +2397,35 @@
                 </button>
                 <button type="submit" form="materialForm" class="btn btn-primary" id="materialSubmitBtn">
                     <span class="btn-icon">➕</span>
+                    Speichern
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Settings Modal -->
+    <div id="settingsModal" class="modal settings-modal">
+        <div class="modal-content modal-large">
+            <div class="modal-header">
+                <div class="settings-modal-title">
+                    <h3>⚙️ Einstellungen</h3>
+                </div>
+                <div class="modal-header-actions">
+                    <select class="modal-tab-selector" onchange="switchModalSettingsTab(this.value)">
+                        <!-- Options populated by JS -->
+                    </select>
+                    <button class="modal-close" onclick="closeSettingsModal()">&times;</button>
+                </div>
+            </div>
+            <div class="modal-body settings-modal-body">
+                <!-- Settings content will be cloned here -->
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" onclick="closeSettingsModal()">
+                    Abbrechen
+                </button>
+                <button type="button" class="btn btn-primary" onclick="saveModalSettings()">
+                    <span class="btn-icon">💾</span>
                     Speichern
                 </button>
             </div>


### PR DESCRIPTION
- Add settings button to Timelapses, Files, Library, and Jobs pages
- Implement modal overlay system for editing settings without leaving page
- Add breadcrumb navigation when navigating to settings page
- Create openPageSettings() utility function with modal/navigation modes
- Add tab selector dropdown in settings modal header
- Style breadcrumb components and large modal layouts

Features:
- Click settings button opens modal with relevant settings tab
- Tab selector allows switching between settings sections in modal
- Breadcrumb shows "← Zurück zu [Page]" for easy navigation
- Settings modal supports save/cancel with API integration
- Clean, responsive UI matching existing design system

Related pages: Timelapses, Files, Library, Jobs, Settings