### PR TITLE
fix(ci): Fix GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,7 +55,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-test.txt
         # Install additional test dependencies for printer integration
-        pip install pytest-mock pytest-asyncio-cooperative pytest-timeout
+        pip install pytest-mock pytest-timeout
 
     - name: Set up database
       run: |

--- a/.github/workflows/sync-ha-addon.yml
+++ b/.github/workflows/sync-ha-addon.yml
@@ -15,7 +15,7 @@ on:
     paths:
       - 'src/**'
       - 'frontend/**'
-      - 'scripts/sync-ha-addon.sh'
+      - 'scripts/deployment/sync-ha-addon.sh'
       - '.github/workflows/sync-ha-addon.yml'
   workflow_dispatch:  # Allow manual trigger
 
@@ -51,8 +51,8 @@ jobs:
 
       - name: Run sync script
         run: |
-          chmod +x scripts/sync-ha-addon.sh
-          ./scripts/sync-ha-addon.sh
+          chmod +x scripts/deployment/sync-ha-addon.sh
+          ./scripts/deployment/sync-ha-addon.sh
 
       - name: Check for sync changes
         id: check_changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ psutil==5.9.6
 
 # Development Dependencies (for testing)
 pytest==7.4.3
-pytest-asyncio==0.21.1
+pytest-asyncio>=0.21.1  # Aligned with requirements-test.txt
 httpx==0.25.2
 pytest-mock==3.12.0
 pytest-cov>=4.1.0  # Coverage reporting


### PR DESCRIPTION
- Fix sync-ha-addon.yml to use correct script path (scripts/deployment/sync-ha-addon.sh)
- Remove incompatible pytest-asyncio-cooperative from CI/CD workflow
- Align pytest-asyncio version between requirements.txt and requirements-test.txt

Fixes #19455441392 (Sync Home Assistant Add-on workflow)
Fixes #19455441386 (CI/CD Pipeline workflow)

The sync workflow was failing because it referenced the wrong script path.
The CI/CD tests were failing due to pytest-asyncio-cooperative being
incompatible with pytest-asyncio (both packages cannot be used together).