### PR TITLE
Fix: Enable navigation reordering via drag-and-drop

### DIFF
--- a/frontend/js/global-drag-drop.js
+++ b/frontend/js/global-drag-drop.js
@@ -53,6 +53,11 @@ class GlobalDragDropManager {
                 // Check if this is an internal drag (like navigation reordering)
                 if (this.isInternalDragEvent(e)) {
                     this.isInternalDrag = true;
+                    // CRITICAL: Must preventDefault on dragover for drops to work
+                    // Without this, the browser blocks the drop and drop event never fires
+                    if (eventName === 'dragover') {
+                        e.preventDefault();
+                    }
                     return; // Let internal drag events pass through
                 }
 


### PR DESCRIPTION
- Added preventDefault() call for internal drag events on dragover
- Critical fix: Without preventDefault on dragover, browser blocks drops
- This allows navigation-preferences-ui.js drag-and-drop to work properly

Fixes #255