### PR TITLE
Fix: Update documentation navigation to use actual file paths

### DIFF
--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -32,10 +32,13 @@ pytest --cov=src --cov-report=html tests/
 
 ## Available Documentation
 
-- **[Unit Testing](unit-testing.md)** - Writing and running unit tests
-- **[Integration Testing](integration-testing.md)** - API and service integration tests
-- **[E2E Testing](e2e-testing.md)** - End-to-end testing architecture
-- **[Coverage Reports](coverage.md)** - Understanding coverage metrics
+- **[Automated Job Creation Testing](automated-job-creation-testing.md)** - Testing automated job creation workflows
+- **[E2E Test Architecture](E2E_ARCHITECTURE.md)** - End-to-end testing architecture and structure
+- **[E2E Testing Quick Reference](E2E_TESTING_QUICKREF.md)** - Quick reference for E2E testing
+- **[E2E Test Analysis](E2E_TEST_ANALYSIS.md)** - Analysis of E2E test results
+- **[Coverage Report Guide](COVERAGE_REPORT_GUIDE.md)** - Generating and understanding coverage reports
+- **[Playwright Setup](PLAYWRIGHT_SETUP_COMPLETE.md)** - Playwright setup documentation
+- **[Testing Guide](TESTING_GUIDE.md)** - Comprehensive testing guide for auto-download system
 
 ## Test Structure
 
@@ -277,9 +280,9 @@ tests/fixtures/
 
 ## Additional Resources
 
-- [Unit Testing Guide](unit-testing.md)
-- [Integration Testing Guide](integration-testing.md)
-- [E2E Testing Architecture](e2e-testing.md)
+- [E2E Test Architecture](E2E_ARCHITECTURE.md)
+- [E2E Testing Quick Reference](E2E_TESTING_QUICKREF.md)
+- [Coverage Report Guide](COVERAGE_REPORT_GUIDE.md)
 - [pytest Documentation](https://docs.pytest.org/)
 
 ## Contributing Tests
@@ -291,4 +294,4 @@ When contributing:
 3. Follow existing test patterns
 4. Update test documentation
 
-See [Development Guide](../development/contributing.md) for more details.
+See the [CONTRIBUTING.md](https://github.com/schmacka/printernizer/blob/master/CONTRIBUTING.md) guide for more details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,36 +97,46 @@ nav:
       - Repository Pattern: architecture/repository-pattern.md
   - API Reference:
       - Overview: api-reference/index.md
-      - Printers API: api-reference/printers.md
-      - Jobs API: api-reference/jobs.md
-      - Files API: api-reference/files.md
-      - Analytics API: api-reference/analytics.md
-      - WebSocket API: api-reference/websocket.md
   - Features:
       - Overview: features/index.md
-      - Auto File Download: features/auto-file-download.md
-      - Job Monitoring: features/job-monitoring.md
-      - File Management: features/file-management.md
-      - Business Analytics: features/business-analytics.md
-      - Metadata System: features/metadata.md
+      - Auto Download System: features/AUTO_DOWNLOAD_SYSTEM.md
+      - 3D Model Metadata: features/ENHANCED_3D_MODEL_METADATA_TECHNICAL.md
+      - Printer Feature Comparison: features/PRINTER_FEATURE_COMPARISON.md
+      - Preview Rendering: features/PREVIEW_RENDERING.md
+      - Thumbnails: features/THUMBNAILS.md
+      - Bambu Lab Thumbnails: features/bambu-thumbnails.md
+      - Frontend Auto Reload: features/FRONTEND_AUTO_RELOAD.md
+      - GCode Optimization: features/GCODE_OPTIMIZATION.md
+      - Trending Models Workflow: features/trending-models-workflow.md
   - Development:
-      - Contributing: development/contributing.md
-      - Development Workflow: development/workflow.md
-      - Code Sync: development/code-sync.md
-      - Testing Guide: development/testing.md
-      - Debugging: development/debugging.md
+      - Overview: development/index.md
+      - Current State: development/CURRENT_STATE.md
+      - Development Plan: development/development-plan.md
+      - Integration Patterns: development/integration_patterns.md
+      - File Operations Guide: development/FILE_OPERATIONS_GUIDE.md
+      - Debug Procedures: development/DEBUG_PROCEDURES.md
+      - Base Service Pattern: development/BASE_SERVICE_PATTERN.md
+      - Startup Optimization: development/STARTUP_OPTIMIZATION_SUMMARY.md
+      - Usage Statistics:
+          - Index: development/usage-statistics-index.md
+          - Technical Spec: development/usage-statistics-technical-spec.md
+          - Implementation Notes: development/usage-statistics-IMPLEMENTATION-NOTES.md
+          - Privacy: development/usage-statistics-privacy.md
+          - Quick Reference: development/usage-statistics-quick-reference.md
+          - Roadmap: development/usage-statistics-roadmap.md
   - Deployment:
       - Overview: deployment/index.md
-      - Docker Standalone: deployment/docker.md
-      - Home Assistant Add-on: deployment/home-assistant.md
-      - Raspberry Pi: deployment/raspberry-pi.md
-      - Production Deployment: deployment/production.md
+      - Production Deployment: deployment/PRODUCTION_DEPLOYMENT.md
+      - GitHub Releases Setup: deployment/GITHUB_RELEASES_SETUP.md
   - Testing:
       - Overview: testing/index.md
-      - Unit Testing: testing/unit-testing.md
-      - Integration Testing: testing/integration-testing.md
-      - E2E Testing: testing/e2e-testing.md
-      - Coverage Reports: testing/coverage.md
+      - Automated Job Creation Testing: testing/automated-job-creation-testing.md
+      - E2E Test Architecture: testing/E2E_ARCHITECTURE.md
+      - E2E Testing Quick Reference: testing/E2E_TESTING_QUICKREF.md
+      - E2E Test Analysis: testing/E2E_TEST_ANALYSIS.md
+      - Coverage Report Guide: testing/COVERAGE_REPORT_GUIDE.md
+      - Playwright Setup: testing/PLAYWRIGHT_SETUP_COMPLETE.md
+      - Testing Guide: testing/TESTING_GUIDE.md
   - Changelog: changelog.md
 
 # Plugins


### PR DESCRIPTION
- Updated mkdocs.yml navigation to point to existing documentation files
- Fixed broken links in testing/index.md to reference actual files
- Removed references to non-existent files (unit-testing.md, integration-testing.md, e2e-testing.md, coverage.md)
- Added proper navigation for Features, Development, Deployment, and Testing sections
- All navigation links now point to actual files that exist in the repository

This resolves 404 errors like https://schmacka.github.io/printernizer/testing/unit-testing.md