### PR TITLE
feat: Move library to second position in navigation

### DIFF
--- a/frontend/js/navigation-preferences.js
+++ b/frontend/js/navigation-preferences.js
@@ -18,6 +18,14 @@ class NavigationPreferences {
                 required: true // Cannot be hidden
             },
             {
+                id: 'library',
+                icon: '🗄️',
+                label: 'Bibliothek',
+                description: 'Zentrale Bibliothek für alle 3D-Dateien mit Metadaten',
+                visible: true,
+                required: false
+            },
+            {
                 id: 'printers',
                 icon: '🖨️',
                 label: 'Drucker',
@@ -46,14 +54,6 @@ class NavigationPreferences {
                 icon: '📁',
                 label: 'Dateien',
                 description: 'Dateiverwaltung und Downloads von den Druckern',
-                visible: true,
-                required: false
-            },
-            {
-                id: 'library',
-                icon: '🗄️',
-                label: 'Bibliothek',
-                description: 'Zentrale Bibliothek für alle 3D-Dateien mit Metadaten',
                 visible: true,
                 required: false
             },


### PR DESCRIPTION
Reordered navigation menu to place Library right after Dashboard,
improving access to the central file library feature.

Navigation order is now:
1. Dashboard
2. Library (moved from position 6)
3. Printers
4. Jobs
5. Timelapses
6. Files
7. Materials
8. Ideas
9. Settings
10. Debug