### PR TITLE
feat: Implement job update and status update API endpoints

### DIFF
--- a/src/models/job.py
+++ b/src/models/job.py
@@ -66,9 +66,84 @@ class JobCreate(BaseModel):
 
 
 class JobUpdate(BaseModel):
-    """Job update model."""
+    """Job update model (legacy - use JobUpdateRequest for new code)."""
     status: Optional[JobStatus] = None
     progress: Optional[int] = None
     material_used: Optional[float] = None
     end_time: Optional[datetime] = None
     actual_duration: Optional[int] = None
+
+
+class JobUpdateRequest(BaseModel):
+    """Schema for job update requests (PUT /api/v1/jobs/{id})."""
+    job_name: Optional[str] = None
+    status: Optional[JobStatus] = None
+    is_business: Optional[bool] = None
+    customer_name: Optional[str] = None
+    notes: Optional[str] = None
+    file_name: Optional[str] = None
+    printer_id: Optional[str] = None
+
+    @field_validator('job_name')
+    @classmethod
+    def validate_job_name(cls, v):
+        if v is not None:
+            v = v.strip()
+            if not v:
+                raise ValueError("job_name cannot be empty")
+            if len(v) > 200:
+                raise ValueError("job_name max length is 200 characters")
+        return v
+
+    @field_validator('customer_name')
+    @classmethod
+    def validate_customer_name(cls, v):
+        if v is not None:
+            v = v.strip()
+            if len(v) > 200:
+                raise ValueError("customer_name max length is 200 characters")
+        return v
+
+    @field_validator('notes')
+    @classmethod
+    def validate_notes(cls, v):
+        if v is not None and len(v) > 1000:
+            raise ValueError("notes max length is 1000 characters")
+        return v
+
+    class Config:
+        """Pydantic configuration."""
+        use_enum_values = True
+
+
+class JobStatusUpdateRequest(BaseModel):
+    """Request schema for job status updates (PUT /api/v1/jobs/{id}/status)."""
+    status: JobStatus
+    completion_notes: Optional[str] = None
+    force: bool = False
+
+    @field_validator('completion_notes')
+    @classmethod
+    def validate_notes(cls, v):
+        if v and len(v) > 500:
+            raise ValueError("completion_notes max length is 500 characters")
+        return v
+
+    class Config:
+        """Pydantic configuration."""
+        use_enum_values = True
+
+
+class JobStatusUpdateResponse(BaseModel):
+    """Response schema for status updates."""
+    id: str
+    status: JobStatus
+    previous_status: JobStatus
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    updated_at: datetime
+
+    class Config:
+        """Pydantic configuration."""
+        from_attributes = True
+        use_enum_values = True


### PR DESCRIPTION
Implements both JOB_UPDATE_API_PLAN.md and JOB_STATUS_UPDATE_PLAN.md

Backend changes:
- Add JobUpdateRequest, JobStatusUpdateRequest, and JobStatusUpdateResponse Pydantic schemas
- Add update_job() method to JobService with business logic validation
- Enhance update_job_status() method with status transition validation
- Add _validate_status_transition() helper method for workflow validation
- Add PUT /api/v1/jobs/{id} endpoint for general job updates
- Add PUT /api/v1/jobs/{id}/status endpoint for status updates with validation

Frontend changes:
- Replace demo mode in jobs.js with actual API call to PUT /api/v1/jobs/{id}
- Add frontend validation for business job customer name requirement
- Implement proper error handling and success messages

Features:
- Job field updates: job_name, status, is_business, customer_name, notes, file_name, printer_id
- Status transition validation with configurable force flag
- Automatic timestamp management (start_time, end_time)
- Completion notes appended to job notes with timestamps
- WebSocket events for real-time updates
- Backward compatible with existing update_job_status() callers