### PR TITLE
docs: Use generic manufacturer references instead of specific printer models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ For detailed information on specific topics, see the Claude Code Skills in `.cla
 
 ## Project Overview
 
-**Printernizer** is a professional 3D print management system designed for managing Bambu Lab A1 and Prusa Core One printers. It provides automated job tracking, file downloads, and business reporting capabilities for 3D printing operations.
+**Printernizer** is a professional 3D print management system designed for managing Bambu Lab and Prusa printers. It provides automated job tracking, file downloads, and business reporting capabilities for 3D printing operations.
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 **Primary Use Case**: Enterprise-grade 3D printer fleet management with automated job monitoring, file organization, and business analytics while maintaining simplicity for individual users.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 [![Documentation](https://img.shields.io/badge/docs-MkDocs-blue)](https://schmacka.github.io/printernizer/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-**Professional 3D Printer Management System for Bambu Lab & Prusa Core One**
+**Professional 3D Printer Management System for Bambu Lab & Prusa Printers**
 
 Enterprise-grade fleet management with real-time monitoring, automated job tracking, file management, and business analytics. Perfect for 3D printing services, maker spaces, educational institutions, and production environments.
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 [📖 Documentation](https://schmacka.github.io/printernizer/) • [🚀 Quick Start](#-quick-start) • [✨ Features](#-features) • [🐳 Deployment](#-deployment-options) • [🤝 Contributing](CONTRIBUTING.md)
 
@@ -73,12 +75,14 @@ Full functionality on mobile devices with optimized responsive layout.
 
 ### 🖨️ Printer Support
 
-- **Bambu Lab A1** - Full MQTT integration with real-time status updates
-- **Prusa Core One** - Complete PrusaLink HTTP API integration
+- **Bambu Lab Printers** - Full MQTT integration with real-time status updates
+- **Prusa Printers** - Complete PrusaLink HTTP API integration
 - **Auto-Discovery** - Automatic printer detection via SSDP + mDNS
 - **Multi-Printer Fleet** - Monitor unlimited printers simultaneously
 - **Connection Health** - Automatic retry, reconnection, and error handling
 - **Live Monitoring** - 30-second polling with WebSocket push updates
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 ### 📊 Real-Time Monitoring & Job Management
 
@@ -162,8 +166,10 @@ Full functionality on mobile devices with optimized responsive layout.
 
 ### Printer Requirements
 
-- **Bambu Lab A1**: IP address, Access Code (8 digits), Serial Number
-- **Prusa Core One**: IP address, PrusaLink API Key
+- **Bambu Lab Printers**: IP address, Access Code (8 digits), Serial Number
+- **Prusa Printers**: IP address, PrusaLink API Key
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 ---
 
@@ -602,7 +608,7 @@ For more troubleshooting tips, see [**Troubleshooting Guide**](https://schmacka.
 
 **Completed Features:**
 - ✅ Complete backend with FastAPI + async SQLite
-- ✅ Full printer integration (Bambu Lab A1 + Prusa Core One)
+- ✅ Full printer integration (Bambu Lab & Prusa manufacturers)
 - ✅ Real-time monitoring with WebSocket updates
 - ✅ Advanced file management and download system
 - ✅ Automated job creation and tracking

--- a/docs/ha-repo-files/README.md
+++ b/docs/ha-repo-files/README.md
@@ -3,7 +3,9 @@
 [![GitHub Release](https://img.shields.io/github/release/schmacka/printernizer-ha.svg)](https://github.com/schmacka/printernizer-ha/releases)
 [![License](https://img.shields.io/github/license/schmacka/printernizer-ha.svg)](https://github.com/schmacka/printernizer-ha/blob/master/LICENSE)
 
-Professional 3D Printer Management for Home Assistant - Bambu Lab A1 and Prusa Core One support.
+Professional 3D Printer Management for Home Assistant - Bambu Lab & Prusa printer support.
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 ## ⚠️ Auto-Synced Repository
 
@@ -19,11 +21,11 @@ This repository is **automatically synchronized** from the main [printernizer](h
 
 ## About
 
-Printernizer is a professional 3D print management system designed for managing Bambu Lab A1 and Prusa Core One printers. It provides automated job tracking, file downloads, and business reporting capabilities for 3D printing operations.
+Printernizer is a professional 3D print management system designed for managing Bambu Lab and Prusa printers. It provides automated job tracking, file downloads, and business reporting capabilities for 3D printing operations.
 
 ### Features
 
-- 🖨️ **Multi-Printer Support**: Manage Bambu Lab A1 and Prusa Core One printers
+- 🖨️ **Multi-Printer Support**: Manage Bambu Lab and Prusa printers
 - 📊 **Job Tracking**: Automatic job monitoring and history
 - 📁 **File Management**: Organize and manage your 3D print files
 - 📈 **Analytics**: Business reporting and usage statistics

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,10 @@
 # Printernizer Documentation
 
-**Professional 3D Printer Management System for Bambu Lab A1 and Prusa Core One**
+**Professional 3D Printer Management System for Bambu Lab & Prusa Printers**
 
 Enterprise-grade fleet management with real-time monitoring, automated file handling, and business analytics. Perfect for 3D printing services, educational institutions, and production environments.
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 ---
 
@@ -62,11 +64,13 @@ Printernizer is a **complete production-ready** 3D printer management system tha
 ## Key Features
 
 ### Printer Support
-- **Bambu Lab A1** - Full MQTT integration with real-time status updates
-- **Prusa Core One** - HTTP API integration via PrusaLink
+- **Bambu Lab Printers** - Full MQTT integration with real-time status updates
+- **Prusa Printers** - HTTP API integration via PrusaLink
 - **Auto-discovery** - Automatically find printers on your network (SSDP + mDNS)
 - **Multi-printer management** - Simultaneous monitoring of multiple printers
 - **Connection health monitoring** - Automatic retry and error handling
+
+> **Tested with:** Bambu Lab A1 and Prusa Core One
 
 ### Real-time Monitoring
 - **Live status updates** - Current printer state, temperatures, progress
@@ -158,7 +162,7 @@ Printernizer is a **complete production-ready** 3D printer management system tha
 
 - ✅ Complete backend with FastAPI + async SQLite
 - ✅ Professional web interface with mobile-responsive design
-- ✅ Full printer integration (Bambu Lab A1 + Prusa Core One)
+- ✅ Full printer integration (Bambu Lab & Prusa manufacturers)
 - ✅ Real-time monitoring with WebSocket updates
 - ✅ File management and download system
 - ✅ 3D preview system (STL, 3MF, GCODE, BGCODE rendering)


### PR DESCRIPTION
Updated documentation to reference manufacturers (Bambu Lab & Prusa) instead
of specific printer models, making it more flexible for future printer support.
Added "Tested with: Bambu Lab A1 and Prusa Core One" notes throughout to
indicate which specific models have been validated.

Changes:
- Updated main project taglines to use manufacturer names
- Modified printer support sections to be more generic
- Added "tested with" notes for specific models
- Applied changes consistently across README.md, CLAUDE.md, docs/index.md,
  and docs/ha-repo-files/README.md

This makes the documentation more future-proof and easier to expand when
adding support for additional models from these manufacturers.