### PR TITLE
fix(deps): Upgrade python-multipart to 0.0.27 to fix CVE-2026-42561

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ scipy>=1.11.0
 networkx>=3.0  # Required by trimesh for 3MF mesh processing
 
 # Security Headers and Middleware
-python-multipart==0.0.26
+python-multipart==0.0.27
 # cryptography>=42.0.0  # Temporarily disabled for Python 3.13 compatibility
 
 # URL Parsing and Web Content Extraction (for Ideas feature)


### PR DESCRIPTION
Resolves a denial-of-service vulnerability in multipart part header
parsing. An attacker could send multipart/form-data with excessive
header count or size, causing CPU exhaustion in FastAPI/Starlette apps.

Fixes #337