### PR TITLE
feat: OpenSCAD parametric model generator module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.0] - 2026-06-13
+
 ### Added
 - OpenSCAD model generator module: a new **Generator** page that renders parametric OpenSCAD models to STL with an interactive 3D viewer (three.js) and PNG preview.
   - Ships with bundled parametric generators (vase, box) exposing sliders, dropdowns and toggles auto-discovered from the OpenSCAD Customizer syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- OpenSCAD model generator module: a new **Generator** page that renders parametric OpenSCAD models to STL with an interactive 3D viewer (three.js) and PNG preview.
+  - Ships with bundled parametric generators (vase, box) exposing sliders, dropdowns and toggles auto-discovered from the OpenSCAD Customizer syntax.
+  - Upload any `.scad` file to auto-discover its parameters and render it.
+  - Generated models can be saved straight into the Library for slicing and printing.
+  - Save and reuse named parameter presets per template.
+  - OpenSCAD is an **optional dependency**: the module auto-detects the binary and degrades gracefully (nav entry hidden) when it is not installed. Configure via `OPENSCAD_BINARY_PATH`; PNG previews use `xvfb-run` automatically on headless hosts.
+
 ## [2.31.0] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ Full functionality on mobile devices with optimized responsive layout.
 - **Processing Queue** - Sequential processing with real-time status updates
 - **Storage Management** - Track video storage and cleanup recommendations
 
+### 🧩 OpenSCAD Model Generator
+
+- **Parametric Generators** - Bundled templates (vase, box) with auto-generated forms
+- **Open Any `.scad` File** - Upload a script and its parameters are auto-discovered
+- **Interactive 3D Viewer** - Inspect rendered STL in-browser (three.js) plus PNG previews
+- **Library Integration** - Save generated models straight into the Library for slicing
+- **Parameter Presets** - Save and reuse named parameter sets per template
+- **Optional Dependency** - Auto-detects OpenSCAD; the feature hides itself if not installed ([docs](docs/openscad-generator.md))
+
 ### 📈 Enhanced 3D Model Metadata
 
 - **Physical Properties** - Dimensions, volume, surface area, object count

--- a/docs/openscad-generator.md
+++ b/docs/openscad-generator.md
@@ -1,0 +1,114 @@
+# OpenSCAD Model Generator
+
+The generator module turns parametric [OpenSCAD](https://openscad.org/) scripts
+into printable models. It renders STL geometry and PNG previews, shows results
+in an interactive 3D viewer, and hands finished models to the Library so they
+flow straight into slicing and printing.
+
+There are two ways to use it:
+
+1. **Bundled generators** — curated templates (e.g. *Parametric Vase*,
+   *Parametric Box*) with friendly forms.
+2. **Upload any `.scad` file** — parameters are auto-discovered and rendered.
+
+## Requirements
+
+OpenSCAD is an **optional dependency**. The module auto-detects the binary at
+startup:
+
+- If OpenSCAD is found, the **Generator** entry appears in the navigation.
+- If not, the module is disabled and the nav entry is hidden — the rest of the
+  app is unaffected.
+
+Install OpenSCAD:
+
+```bash
+# Debian/Ubuntu (incl. Raspberry Pi / Docker base images)
+apt-get install -y openscad
+
+# For PNG previews on a headless host, also install xvfb
+apt-get install -y xvfb
+```
+
+STL rendering runs headless out of the box. PNG previews need an X server, so on
+headless hosts the service automatically wraps OpenSCAD with `xvfb-run` when it
+is available.
+
+### Configuration
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `OPENSCAD_BINARY_PATH` | _(auto-detect on `PATH`)_ | Explicit path to the OpenSCAD binary. |
+| `OPENSCAD_RENDER_TIMEOUT` | `120` | Max seconds for a single render. |
+| `OPENSCAD_MAX_OUTPUT_MB` | `100` | Max size of a render artifact (guards against runaway uploads). |
+| `GENERATOR_OUTPUT_DIR` | `/data/printernizer/generator` | Working dir for uploads and render artifacts. |
+
+## Parameters (Customizer syntax)
+
+Parameters are top-level variables annotated with OpenSCAD's Customizer comment
+syntax. The parser produces the form controls automatically:
+
+```openscad
+/* [Dimensions] */
+// Total height in mm          <- description (line above)
+height = 120;        // [40:300]      number slider (min:max)
+wall = 2;            // [0.8:0.2:6]   number slider (min:step:max)
+
+/* [Style] */
+style = "smooth";    // [smooth, faceted, ribbed]   dropdown
+sides = 6;           // [3, 6, 12, 24]               numeric dropdown
+closed = true;                                       boolean checkbox
+
+/* [Hidden] */
+internal = 5;        // excluded from the form
+```
+
+Variables declared inside `module`/`function` bodies are ignored — only
+top-level assignments become parameters, matching OpenSCAD's own Customizer.
+
+## Adding a bundled generator
+
+Drop two files into [`src/scad_templates/`](../src/scad_templates):
+
+- `my_generator.scad` — the OpenSCAD source (using the Customizer syntax above).
+- `my_generator.json` — optional metadata:
+
+```json
+{
+  "name": "My Generator",
+  "description": "What it makes",
+  "category": "Containers",
+  "default_camera": "0,0,60,60,0,30,420"
+}
+```
+
+`default_camera` is the OpenSCAD `--camera` string
+(`translate_x,translate_y,translate_z,rot_x,rot_y,rot_z,distance`) used for PNG
+previews. The template is picked up automatically on startup.
+
+## API
+
+Base path: `/api/v1/generator`
+
+| Method & path | Purpose |
+|---------------|---------|
+| `GET /status` | OpenSCAD availability + version |
+| `GET /templates` | List bundled templates with parameter schemas |
+| `GET /templates/{id}` | Template detail incl. source |
+| `POST /parse` | Parse parameters from raw source `{ "source": "..." }` |
+| `POST /upload` | Upload a `.scad` file (multipart) → id + schema |
+| `POST /render` | Render `{ source_ref, parameters, format }` (`stl`/`png`) |
+| `GET /render/{id}/model.stl` | Download STL artifact |
+| `GET /render/{id}/preview.png` | Download PNG preview |
+| `POST /render/{id}/save` | Save STL into the Library |
+| `GET/POST /presets`, `DELETE /presets/{id}` | Manage parameter presets |
+
+Render lifecycle events (`openscad.generation.started/completed/failed`) are
+emitted over the existing WebSocket channel for live UI feedback.
+
+## Security note
+
+Uploaded `.scad` files are executed by OpenSCAD. OpenSCAD has no `system()`
+call, but `import`/`include`/`use` can read files. The module applies a render
+timeout, an output-size cap, and an isolated working directory per render as
+best-effort sandboxing. Only allow uploads from trusted users.

--- a/frontend/css/generator.css
+++ b/frontend/css/generator.css
@@ -1,0 +1,166 @@
+/* OpenSCAD Generator page styles */
+
+.generator-unavailable {
+    margin: 1rem 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--border-color, #d0d0d8);
+    border-radius: 8px;
+    background: var(--surface-alt, #f7f7fa);
+    color: var(--text-secondary, #555);
+}
+
+.generator-layout {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.generator-sidebar {
+    position: sticky;
+    top: 1rem;
+}
+
+.generator-section h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+}
+
+.generator-templates {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.generator-template-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    text-align: left;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--border-color, #d0d0d8);
+    border-radius: 8px;
+    background: var(--surface, #fff);
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.generator-template-card:hover {
+    border-color: var(--primary, #4a9eda);
+}
+
+.generator-template-card.active {
+    border-color: var(--primary, #4a9eda);
+    background: var(--primary-soft, rgba(74, 158, 218, 0.12));
+}
+
+.generator-template-card span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #666);
+}
+
+.generator-upload-btn {
+    width: 100%;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.generator-main {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.generator-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.generator-fieldset {
+    border: 1px solid var(--border-color, #d0d0d8);
+    border-radius: 8px;
+    padding: 0.75rem 1rem 1rem;
+}
+
+.generator-fieldset legend {
+    padding: 0 0.4rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.generator-field {
+    display: grid;
+    grid-template-columns: 1fr minmax(120px, 200px);
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.6rem;
+}
+
+.generator-field label {
+    font-size: 0.875rem;
+}
+
+.generator-input {
+    width: 100%;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--border-color, #d0d0d8);
+    border-radius: 6px;
+}
+
+.generator-input[type="checkbox"] {
+    width: auto;
+    justify-self: start;
+}
+
+.generator-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.generator-viewer-wrap {
+    position: relative;
+    min-height: 400px;
+    border: 1px solid var(--border-color, #d0d0d8);
+    border-radius: 8px;
+    overflow: hidden;
+    background: #1e1e24;
+}
+
+.generator-viewer {
+    width: 100%;
+    height: 400px;
+}
+
+.generator-preview-image {
+    display: block;
+    max-width: 100%;
+    margin: 0 auto;
+}
+
+.generator-viewer-status {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #c9c9d4;
+    text-align: center;
+    padding: 1rem;
+    pointer-events: none;
+}
+
+@media (max-width: 900px) {
+    .generator-layout {
+        grid-template-columns: 1fr;
+    }
+    .generator-sidebar {
+        position: static;
+    }
+    .generator-field {
+        grid-template-columns: 1fr;
+        gap: 0.3rem;
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="css/themes/theme-retro.css">
     <link rel="stylesheet" href="css/admin-statistics.css">
     <link rel="stylesheet" href="css/tools.css">
+    <link rel="stylesheet" href="css/generator.css">
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
     <!-- Logger must be loaded before theme-switcher -->
     <script src="js/logger.js"></script>
@@ -88,6 +89,11 @@
                    role="button" aria-describedby="nav-tools-desc">
                     <span class="nav-icon" aria-hidden="true">🛠️</span>
                     <span data-i18n="nav.tools">Tools</span>
+                </a>
+                <a href="#generator" class="nav-link" data-page="generator" id="nav-generator-link"
+                   role="button" aria-describedby="nav-generator-desc" style="display: none;">
+                    <span class="nav-icon" aria-hidden="true">🧩</span>
+                    <span data-i18n="nav.generator">Generator</span>
                 </a>
                 <a href="#settings" class="nav-link" data-page="settings"
                    role="button" aria-describedby="nav-settings-desc">
@@ -2076,6 +2082,52 @@
             </div>
         </div>
 
+        <!-- OpenSCAD Generator Page -->
+        <div id="generator" class="page">
+            <div class="page-header">
+                <h1>🧩 <span data-i18n="generator.pageTitle">Modell-Generator</span></h1>
+                <div class="header-subtitle" data-i18n="generator.subtitle">Parametrische OpenSCAD-Modelle erzeugen, rendern und in die Bibliothek speichern</div>
+            </div>
+            <div id="generatorUnavailable" class="generator-unavailable" style="display: none;">
+                <p data-i18n="generator.unavailable">OpenSCAD ist nicht installiert. Installieren Sie OpenSCAD oder setzen Sie OPENSCAD_BINARY_PATH, um den Generator zu aktivieren.</p>
+            </div>
+            <div class="generator-layout" id="generatorLayout">
+                <aside class="generator-sidebar">
+                    <div class="generator-section">
+                        <h3 data-i18n="generator.templates">Vorlagen</h3>
+                        <div id="generatorTemplates" class="generator-templates"></div>
+                        <label class="btn btn-secondary btn-sm generator-upload-btn">
+                            <span class="btn-icon">📁</span>
+                            <span data-i18n="generator.upload">.scad hochladen</span>
+                            <input type="file" id="generatorUpload" accept=".scad" hidden>
+                        </label>
+                    </div>
+                </aside>
+                <main class="generator-main">
+                    <form id="generatorForm" class="generator-form"></form>
+                    <div class="generator-actions">
+                        <button type="button" class="btn btn-secondary" id="generatorPreviewBtn" disabled>
+                            <span class="btn-icon">🖼️</span>
+                            <span data-i18n="generator.preview">Vorschau</span>
+                        </button>
+                        <button type="button" class="btn btn-primary" id="generatorRenderBtn" disabled>
+                            <span class="btn-icon">⚙️</span>
+                            <span data-i18n="generator.render">Rendern (STL)</span>
+                        </button>
+                        <button type="button" class="btn btn-secondary" id="generatorSaveBtn" disabled>
+                            <span class="btn-icon">💾</span>
+                            <span data-i18n="generator.saveToLibrary">In Bibliothek speichern</span>
+                        </button>
+                    </div>
+                    <div class="generator-viewer-wrap">
+                        <div id="generatorViewer" class="generator-viewer"></div>
+                        <img id="generatorPreviewImage" class="generator-preview-image" alt="" style="display: none;">
+                        <div id="generatorViewerStatus" class="generator-viewer-status" data-i18n="generator.selectTemplate">Wählen Sie eine Vorlage, um zu beginnen.</div>
+                    </div>
+                </main>
+            </div>
+        </div>
+
         <!-- Tools & Helpers Page -->
         <div id="tools" class="page">
             <div class="page-header">
@@ -3019,6 +3071,11 @@
     <script src="js/global-drag-drop.js"></script>
     <script src="js/setup-wizard.js"></script>
     <script src="js/preview-3d.js"></script>
+    <!-- three.js for the OpenSCAD generator's interactive 3D viewer -->
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/STLLoader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="js/generator.js"></script>
 
     <script src="js/main.js?v=1.5"></script>
 

--- a/frontend/js/generator.js
+++ b/frontend/js/generator.js
@@ -1,0 +1,387 @@
+/**
+ * OpenSCAD Generator page manager.
+ *
+ * Lists bundled parametric templates and accepts arbitrary .scad uploads,
+ * builds a dynamic form from each script's discovered parameters, renders a
+ * PNG preview / STL via the backend, shows the STL in an interactive three.js
+ * viewer, and saves results into the Library.
+ */
+class GeneratorManager {
+    constructor() {
+        this.available = false;
+        this.templates = [];
+        this.currentSourceRef = null;
+        this.currentParameters = [];
+        this.lastRenderId = null;
+        this.three = null; // { renderer, scene, camera, controls, mesh, animationId }
+        this._initialized = false;
+    }
+
+    _t(key, fallback) {
+        return (typeof t === 'function') ? t(key) : fallback;
+    }
+
+    _toast(type, message) {
+        if (typeof showToast === 'function') {
+            showToast(type, this._t('generator.pageTitle', 'Generator'), message);
+        } else {
+            console.log(`[generator:${type}] ${message}`);
+        }
+    }
+
+    async init() {
+        // Re-check availability each time the page is opened.
+        await this.checkStatus();
+        if (!this.available) return;
+        if (this._initialized) return;
+        this._initialized = true;
+
+        document.getElementById('generatorPreviewBtn')?.addEventListener('click', () => this.render('png'));
+        document.getElementById('generatorRenderBtn')?.addEventListener('click', () => this.render('stl'));
+        document.getElementById('generatorSaveBtn')?.addEventListener('click', () => this.saveToLibrary());
+        document.getElementById('generatorUpload')?.addEventListener('change', (e) => this.handleUpload(e));
+
+        await this.loadTemplates();
+    }
+
+    cleanup() {
+        this._stopAnimation();
+    }
+
+    async checkStatus() {
+        try {
+            const status = await api.get('/generator/status');
+            this.available = !!status.available;
+        } catch (e) {
+            this.available = false;
+        }
+        const layout = document.getElementById('generatorLayout');
+        const unavailable = document.getElementById('generatorUnavailable');
+        const navLink = document.getElementById('nav-generator-link');
+        if (navLink) navLink.style.display = this.available ? '' : 'none';
+        if (layout) layout.style.display = this.available ? '' : 'none';
+        if (unavailable) unavailable.style.display = this.available ? 'none' : 'block';
+    }
+
+    async loadTemplates() {
+        try {
+            this.templates = await api.get('/generator/templates');
+            this.renderTemplateList();
+        } catch (e) {
+            this._toast('error', this._t('generator.loadFailed', 'Failed to load templates'));
+        }
+    }
+
+    renderTemplateList() {
+        const container = document.getElementById('generatorTemplates');
+        if (!container) return;
+        container.innerHTML = '';
+        this.templates.forEach((tpl) => {
+            const card = document.createElement('button');
+            card.type = 'button';
+            card.className = 'generator-template-card';
+            card.dataset.id = tpl.id;
+            card.innerHTML = `<strong>${escapeHtml(tpl.name)}</strong>` +
+                (tpl.description ? `<span>${escapeHtml(tpl.description)}</span>` : '');
+            card.addEventListener('click', () => this.selectTemplate(tpl.id));
+            container.appendChild(card);
+        });
+    }
+
+    async selectTemplate(templateId) {
+        try {
+            const tpl = await api.get(`/generator/templates/${encodeURIComponent(templateId)}`);
+            this.setActiveSource(tpl.id, tpl.parameters);
+            this._highlightCard(tpl.id);
+        } catch (e) {
+            this._toast('error', this._t('generator.loadFailed', 'Failed to load template'));
+        }
+    }
+
+    _highlightCard(id) {
+        document.querySelectorAll('.generator-template-card').forEach((el) => {
+            el.classList.toggle('active', el.dataset.id === id);
+        });
+    }
+
+    setActiveSource(sourceRef, parameters) {
+        this.currentSourceRef = sourceRef;
+        this.currentParameters = parameters || [];
+        this.lastRenderId = null;
+        this.buildForm();
+        document.getElementById('generatorPreviewBtn').disabled = false;
+        document.getElementById('generatorRenderBtn').disabled = false;
+        document.getElementById('generatorSaveBtn').disabled = true;
+    }
+
+    buildForm() {
+        const form = document.getElementById('generatorForm');
+        if (!form) return;
+        form.innerHTML = '';
+
+        // Group parameters by their section.
+        const groups = new Map();
+        this.currentParameters.forEach((p) => {
+            const key = p.group || '';
+            if (!groups.has(key)) groups.set(key, []);
+            groups.get(key).push(p);
+        });
+
+        groups.forEach((params, groupName) => {
+            const fieldset = document.createElement('fieldset');
+            fieldset.className = 'generator-fieldset';
+            if (groupName) {
+                const legend = document.createElement('legend');
+                legend.textContent = groupName;
+                fieldset.appendChild(legend);
+            }
+            params.forEach((p) => fieldset.appendChild(this._buildField(p)));
+            form.appendChild(fieldset);
+        });
+    }
+
+    _buildField(param) {
+        const wrap = document.createElement('div');
+        wrap.className = 'generator-field';
+        const label = document.createElement('label');
+        label.textContent = param.description || param.name;
+        label.htmlFor = `gen_${param.name}`;
+        wrap.appendChild(label);
+
+        let input;
+        if (param.type === 'boolean') {
+            input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = !!param.default;
+        } else if (param.type === 'enum') {
+            input = document.createElement('select');
+            (param.options || []).forEach((opt) => {
+                const o = document.createElement('option');
+                o.value = String(opt);
+                o.textContent = String(opt);
+                if (String(opt) === String(param.default)) o.selected = true;
+                input.appendChild(o);
+            });
+        } else if (param.type === 'number') {
+            input = document.createElement('input');
+            input.type = 'number';
+            if (param.min !== null && param.min !== undefined) input.min = param.min;
+            if (param.max !== null && param.max !== undefined) input.max = param.max;
+            if (param.step !== null && param.step !== undefined) input.step = param.step;
+            input.value = param.default ?? '';
+        } else {
+            input = document.createElement('input');
+            input.type = 'text';
+            input.value = param.default ?? '';
+        }
+        input.id = `gen_${param.name}`;
+        input.dataset.param = param.name;
+        input.dataset.type = param.type;
+        input.className = 'generator-input';
+        wrap.appendChild(input);
+        return wrap;
+    }
+
+    collectParameters() {
+        const params = {};
+        document.querySelectorAll('#generatorForm [data-param]').forEach((el) => {
+            const name = el.dataset.param;
+            const type = el.dataset.type;
+            if (type === 'boolean') {
+                params[name] = el.checked;
+            } else if (type === 'number') {
+                if (el.value !== '') params[name] = Number(el.value);
+            } else if (type === 'enum') {
+                const num = Number(el.value);
+                params[name] = (el.value !== '' && !Number.isNaN(num)) ? num : el.value;
+            } else {
+                params[name] = el.value;
+            }
+        });
+        return params;
+    }
+
+    async render(format) {
+        if (!this.currentSourceRef) return;
+        const statusEl = document.getElementById('generatorViewerStatus');
+        const setBusy = (busy) => {
+            document.getElementById('generatorPreviewBtn').disabled = busy;
+            document.getElementById('generatorRenderBtn').disabled = busy;
+        };
+        setBusy(true);
+        if (statusEl) {
+            statusEl.style.display = 'block';
+            statusEl.textContent = this._t('generator.rendering', 'Rendering…');
+        }
+        try {
+            const result = await api.post('/generator/render', {
+                source_ref: this.currentSourceRef,
+                parameters: this.collectParameters(),
+                format,
+            });
+            this.lastRenderId = result.render_id;
+            if (format === 'png') {
+                this._showPreviewImage(result.render_id);
+            } else {
+                document.getElementById('generatorSaveBtn').disabled = false;
+                await this._showStl(result.render_id);
+            }
+        } catch (e) {
+            const msg = (e && e.message) ? e.message : this._t('generator.renderFailed', 'Render failed');
+            this._toast('error', msg);
+            if (statusEl) { statusEl.style.display = 'block'; statusEl.textContent = msg; }
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    _artifactUrl(renderId, name) {
+        return `${api.baseURL.replace(/\/+$/, '')}/generator/render/${renderId}/${name}`;
+    }
+
+    _showPreviewImage(renderId) {
+        const img = document.getElementById('generatorPreviewImage');
+        const viewer = document.getElementById('generatorViewer');
+        const statusEl = document.getElementById('generatorViewerStatus');
+        if (viewer) viewer.style.display = 'none';
+        this._stopAnimation();
+        if (img) {
+            img.src = this._artifactUrl(renderId, 'preview.png') + `?t=${Date.now()}`;
+            img.style.display = 'block';
+        }
+        if (statusEl) statusEl.style.display = 'none';
+    }
+
+    async _showStl(renderId) {
+        const img = document.getElementById('generatorPreviewImage');
+        const viewer = document.getElementById('generatorViewer');
+        const statusEl = document.getElementById('generatorViewerStatus');
+        if (img) img.style.display = 'none';
+
+        if (typeof THREE === 'undefined' || typeof THREE.STLLoader === 'undefined') {
+            // Fallback: no WebGL libs available, show a PNG preview instead.
+            this._toast('warning', this._t('generator.viewerUnavailable', '3D viewer unavailable, showing image'));
+            await this.render('png');
+            return;
+        }
+        if (viewer) viewer.style.display = 'block';
+        if (statusEl) statusEl.style.display = 'none';
+        this._ensureThree();
+
+        const loader = new THREE.STLLoader();
+        loader.load(this._artifactUrl(renderId, 'model.stl') + `?t=${Date.now()}`, (geometry) => {
+            this._setMesh(geometry);
+        }, undefined, () => {
+            this._toast('error', this._t('generator.renderFailed', 'Failed to load model'));
+        });
+    }
+
+    _ensureThree() {
+        const container = document.getElementById('generatorViewer');
+        if (!container || this.three) return;
+        const width = container.clientWidth || 600;
+        const height = container.clientHeight || 400;
+
+        const scene = new THREE.Scene();
+        scene.background = new THREE.Color(0x1e1e24);
+        const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 5000);
+        camera.position.set(120, 120, 120);
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setSize(width, height);
+        container.innerHTML = '';
+        container.appendChild(renderer.domElement);
+
+        scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+        const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+        dir.position.set(1, 1, 1);
+        scene.add(dir);
+
+        let controls = null;
+        if (typeof THREE.OrbitControls !== 'undefined') {
+            controls = new THREE.OrbitControls(camera, renderer.domElement);
+            controls.enableDamping = true;
+        }
+
+        this.three = { renderer, scene, camera, controls, mesh: null, animationId: null };
+        const animate = () => {
+            this.three.animationId = requestAnimationFrame(animate);
+            if (controls) controls.update();
+            renderer.render(scene, camera);
+        };
+        animate();
+    }
+
+    _setMesh(geometry) {
+        const { scene, camera, controls } = this.three;
+        if (this.three.mesh) {
+            scene.remove(this.three.mesh);
+            this.three.mesh.geometry.dispose();
+            this.three.mesh.material.dispose();
+        }
+        geometry.computeBoundingBox();
+        geometry.center();
+        const material = new THREE.MeshPhongMaterial({ color: 0x4a9eda, specular: 0x111111, shininess: 30 });
+        const mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+        this.three.mesh = mesh;
+
+        // Frame the model.
+        const size = new THREE.Vector3();
+        geometry.boundingBox.getSize(size);
+        const maxDim = Math.max(size.x, size.y, size.z) || 50;
+        camera.position.set(maxDim * 1.6, maxDim * 1.6, maxDim * 1.6);
+        camera.lookAt(0, 0, 0);
+        if (controls) { controls.target.set(0, 0, 0); controls.update(); }
+    }
+
+    _stopAnimation() {
+        if (this.three && this.three.animationId) {
+            cancelAnimationFrame(this.three.animationId);
+            this.three.animationId = null;
+        }
+    }
+
+    async saveToLibrary() {
+        if (!this.lastRenderId) return;
+        try {
+            await api.post(`/generator/render/${this.lastRenderId}/save`, {});
+            this._toast('success', this._t('generator.saved', 'Saved to library'));
+        } catch (e) {
+            const msg = (e && e.message) ? e.message : this._t('generator.saveFailed', 'Save failed');
+            this._toast('error', msg);
+        }
+    }
+
+    async handleUpload(event) {
+        const file = event.target.files && event.target.files[0];
+        if (!file) return;
+        const formData = new FormData();
+        formData.append('file', file);
+        try {
+            const response = await fetch(`${api.baseURL.replace(/\/+$/, '')}/generator/upload`, {
+                method: 'POST', body: formData,
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.message || err.detail?.message || 'Upload failed');
+            }
+            const tpl = await response.json();
+            this.setActiveSource(tpl.id, tpl.parameters);
+            this._highlightCard(null);
+            this._toast('success', this._t('generator.uploaded', 'File uploaded'));
+        } catch (e) {
+            this._toast('error', e.message);
+        } finally {
+            event.target.value = '';
+        }
+    }
+}
+
+const generatorManager = new GeneratorManager();
+
+// Reveal the nav entry on startup when OpenSCAD is available.
+document.addEventListener('DOMContentLoaded', () => {
+    if (typeof api !== 'undefined') {
+        generatorManager.checkStatus().catch(() => {});
+    }
+});

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -14,6 +14,7 @@ const AVAILABLE_PAGES = [
     'materials',
     'ideas',
     'tools',
+    'generator',
     'settings',
     'debug'
 ];
@@ -35,6 +36,7 @@ class PrinternizerApp {
             materials: typeof materialsManager !== 'undefined' ? materialsManager : null,
             ideas: typeof initializeIdeas !== 'undefined' ? { init: initializeIdeas } : null,
             tools: typeof toolsManager !== 'undefined' ? toolsManager : null,
+            generator: typeof generatorManager !== 'undefined' ? generatorManager : null,
             settings: typeof settingsManager !== 'undefined' ? settingsManager : null,
             debug: typeof debugManager !== 'undefined' ? debugManager : null
         };

--- a/frontend/locales/de.json
+++ b/frontend/locales/de.json
@@ -10,9 +10,28 @@
     "materials": "Filamente",
     "ideas": "Ideen",
     "tools": "Tools",
+    "generator": "Generator",
     "settings": "Einstellungen",
     "debug": "Debug",
     "connectionStatus": "Verbindung"
+  },
+  "generator": {
+    "pageTitle": "Modell-Generator",
+    "subtitle": "Parametrische OpenSCAD-Modelle erzeugen, rendern und in die Bibliothek speichern",
+    "unavailable": "OpenSCAD ist nicht installiert. Installieren Sie OpenSCAD oder setzen Sie OPENSCAD_BINARY_PATH, um den Generator zu aktivieren.",
+    "templates": "Vorlagen",
+    "upload": ".scad hochladen",
+    "preview": "Vorschau",
+    "render": "Rendern (STL)",
+    "saveToLibrary": "In Bibliothek speichern",
+    "selectTemplate": "Wählen Sie eine Vorlage, um zu beginnen.",
+    "rendering": "Wird gerendert…",
+    "loadFailed": "Vorlagen konnten nicht geladen werden",
+    "renderFailed": "Rendern fehlgeschlagen",
+    "saved": "In Bibliothek gespeichert",
+    "saveFailed": "Speichern fehlgeschlagen",
+    "uploaded": "Datei hochgeladen",
+    "viewerUnavailable": "3D-Ansicht nicht verfügbar, zeige Bild"
   },
   "common": {
     "save": "Speichern",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -10,9 +10,28 @@
     "materials": "Filaments",
     "ideas": "Ideas",
     "tools": "Tools",
+    "generator": "Generator",
     "settings": "Settings",
     "debug": "Debug",
     "connectionStatus": "Connection status"
+  },
+  "generator": {
+    "pageTitle": "Model Generator",
+    "subtitle": "Generate parametric OpenSCAD models, render them and save into the library",
+    "unavailable": "OpenSCAD is not installed. Install OpenSCAD or set OPENSCAD_BINARY_PATH to enable the generator.",
+    "templates": "Templates",
+    "upload": "Upload .scad",
+    "preview": "Preview",
+    "render": "Render (STL)",
+    "saveToLibrary": "Save to library",
+    "selectTemplate": "Select a template to get started.",
+    "rendering": "Rendering…",
+    "loadFailed": "Failed to load templates",
+    "renderFailed": "Render failed",
+    "saved": "Saved to library",
+    "saveFailed": "Save failed",
+    "uploaded": "File uploaded",
+    "viewerUnavailable": "3D viewer unavailable, showing image"
   },
   "common": {
     "save": "Save",

--- a/migrations/032_add_openscad_tables.sql
+++ b/migrations/032_add_openscad_tables.sql
@@ -1,0 +1,29 @@
+-- Migration: 032_add_openscad_tables
+-- Description: Add tables for the OpenSCAD generator module (renders and presets)
+-- Date: 2026-06-13
+
+CREATE TABLE IF NOT EXISTS openscad_renders (
+    id TEXT PRIMARY KEY NOT NULL,
+    source_ref TEXT NOT NULL,           -- template id or uploaded source id
+    parameters TEXT,                    -- JSON of parameter overrides
+    format TEXT NOT NULL DEFAULT 'stl', -- 'stl' or 'png'
+    status TEXT NOT NULL DEFAULT 'pending',
+    work_dir TEXT,                      -- isolated working directory
+    model_path TEXT,                    -- path to rendered STL
+    preview_path TEXT,                  -- path to rendered PNG
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_openscad_renders_source ON openscad_renders(source_ref);
+CREATE INDEX IF NOT EXISTS idx_openscad_renders_created ON openscad_renders(created_at);
+
+CREATE TABLE IF NOT EXISTS openscad_presets (
+    id TEXT PRIMARY KEY NOT NULL,
+    template_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    parameters TEXT,                    -- JSON of parameter values
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_openscad_presets_template ON openscad_presets(template_id);

--- a/src/api/routers/generator.py
+++ b/src/api/routers/generator.py
@@ -1,0 +1,148 @@
+"""
+OpenSCAD Generator API router.
+
+Endpoints for the parametric model generator: query availability, list/inspect
+bundled templates, upload and parse arbitrary .scad files, render to STL/PNG,
+serve render artifacts, save results to the Library, and manage presets.
+"""
+from typing import Any, Dict, List, Optional
+
+import structlog
+from fastapi import APIRouter, Depends, Query, Request, UploadFile, File
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from src.models.generator import (
+    GeneratorStatus,
+    Preset,
+    PresetRequest,
+    RenderRequest,
+    RenderResult,
+    ScadParameter,
+    ScadTemplate,
+)
+from src.services.generator_service import GeneratorService
+from src.utils.errors import NotFoundError, OpenSCADNotAvailableError, ValidationError
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+MAX_UPLOAD_BYTES = 2 * 1024 * 1024  # 2 MB is plenty for a .scad source file
+
+
+async def get_generator_service(request: Request) -> GeneratorService:
+    """Get generator service instance from app state."""
+    return request.app.state.generator_service
+
+
+class ParseRequest(BaseModel):
+    """Request to parse parameters from raw OpenSCAD source."""
+    source: str
+
+
+class SaveRequest(BaseModel):
+    """Request to save a render into the Library."""
+    display_name: Optional[str] = None
+
+
+@router.get("/status", response_model=GeneratorStatus)
+async def get_status(service: GeneratorService = Depends(get_generator_service)):
+    """Report whether OpenSCAD is available (drives conditional UI)."""
+    return service.get_status()
+
+
+@router.get("/templates", response_model=List[ScadTemplate])
+async def list_templates(service: GeneratorService = Depends(get_generator_service)):
+    """List bundled generator templates with their parameter schemas."""
+    return service.list_templates()
+
+
+@router.get("/templates/{template_id}", response_model=ScadTemplate)
+async def get_template(template_id: str,
+                       service: GeneratorService = Depends(get_generator_service)):
+    """Get a single template including its OpenSCAD source."""
+    return service.get_template(template_id)
+
+
+@router.post("/parse", response_model=List[ScadParameter])
+async def parse_source(body: ParseRequest,
+                       service: GeneratorService = Depends(get_generator_service)):
+    """Parse parameters from pasted OpenSCAD source."""
+    return service.parse_source(body.source)
+
+
+@router.post("/upload", response_model=ScadTemplate)
+async def upload_scad(file: UploadFile = File(...),
+                      service: GeneratorService = Depends(get_generator_service)):
+    """Upload an arbitrary .scad file and auto-discover its parameters."""
+    filename = file.filename or "uploaded.scad"
+    if not filename.lower().endswith(".scad"):
+        raise ValidationError("file", "Only .scad files are accepted")
+    content = await file.read()
+    if len(content) > MAX_UPLOAD_BYTES:
+        raise ValidationError("file", "File exceeds the 2 MB limit")
+    try:
+        source = content.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ValidationError("file", "File is not valid UTF-8 text")
+    return service.store_upload(source, filename=filename)
+
+
+@router.post("/render", response_model=RenderResult)
+async def render(body: RenderRequest,
+                 service: GeneratorService = Depends(get_generator_service)):
+    """Render a template/upload to STL or PNG with parameter overrides."""
+    if not service.openscad.available:
+        raise OpenSCADNotAvailableError()
+    return await service.render(body.source_ref, body.parameters, fmt=body.format.value)
+
+
+@router.get("/render/{render_id}/model.stl")
+async def get_render_model(render_id: str,
+                           service: GeneratorService = Depends(get_generator_service)):
+    """Serve the STL artifact for a render."""
+    path = await service.get_artifact_path(render_id, "model")
+    if not path:
+        raise NotFoundError("render artifact", render_id)
+    return FileResponse(path, media_type="model/stl", filename=f"{render_id}.stl")
+
+
+@router.get("/render/{render_id}/preview.png")
+async def get_render_preview(render_id: str,
+                             service: GeneratorService = Depends(get_generator_service)):
+    """Serve the PNG preview for a render."""
+    path = await service.get_artifact_path(render_id, "preview")
+    if not path:
+        raise NotFoundError("render artifact", render_id)
+    return FileResponse(path, media_type="image/png")
+
+
+@router.post("/render/{render_id}/save")
+async def save_render_to_library(render_id: str, body: SaveRequest,
+                                 service: GeneratorService = Depends(get_generator_service)):
+    """Save a completed STL render into the Library for slicing/printing."""
+    result = await service.save_to_library(render_id, display_name=body.display_name)
+    return {"status": "success", "data": result}
+
+
+@router.get("/presets", response_model=List[Preset])
+async def list_presets(template_id: Optional[str] = Query(None),
+                       service: GeneratorService = Depends(get_generator_service)):
+    """List saved parameter presets, optionally filtered by template."""
+    return await service.list_presets(template_id)
+
+
+@router.post("/presets", response_model=Preset)
+async def create_preset(body: PresetRequest,
+                        service: GeneratorService = Depends(get_generator_service)):
+    """Save a named parameter preset for a template."""
+    return await service.save_preset(body.template_id, body.name, body.parameters)
+
+
+@router.delete("/presets/{preset_id}")
+async def delete_preset(preset_id: str,
+                        service: GeneratorService = Depends(get_generator_service)):
+    """Delete a saved preset."""
+    await service.delete_preset(preset_id)
+    return {"status": "success"}

--- a/src/database/repositories/__init__.py
+++ b/src/database/repositories/__init__.py
@@ -16,6 +16,7 @@ from .usage_statistics_repository import UsageStatisticsRepository
 from .notification_repository import NotificationRepository
 from .customer_repository import CustomerRepository
 from .order_repository import OrderRepository
+from .openscad_repository import OpenSCADRepository
 
 __all__ = [
     'BaseRepository',
@@ -30,4 +31,5 @@ __all__ = [
     'NotificationRepository',
     'CustomerRepository',
     'OrderRepository',
+    'OpenSCADRepository',
 ]

--- a/src/database/repositories/openscad_repository.py
+++ b/src/database/repositories/openscad_repository.py
@@ -1,0 +1,90 @@
+"""
+Repository for OpenSCAD generator data (renders and parameter presets).
+"""
+import json
+from typing import Any, Dict, List, Optional
+
+from .base_repository import BaseRepository
+
+
+class OpenSCADRepository(BaseRepository):
+    """Data access for OpenSCAD renders and presets."""
+
+    # ---- Renders -----------------------------------------------------------
+
+    async def create_render(self, render: Dict[str, Any]) -> None:
+        """Persist a render record."""
+        await self._execute_write(
+            """
+            INSERT INTO openscad_renders
+                (id, source_ref, parameters, format, status, work_dir,
+                 model_path, preview_path, error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                render["id"],
+                render["source_ref"],
+                json.dumps(render.get("parameters", {})),
+                render.get("format", "stl"),
+                render.get("status", "pending"),
+                render.get("work_dir"),
+                render.get("model_path"),
+                render.get("preview_path"),
+                render.get("error"),
+            ),
+        )
+
+    async def update_render(self, render_id: str, fields: Dict[str, Any]) -> None:
+        """Update mutable fields of a render record."""
+        if not fields:
+            return
+        columns = ", ".join(f"{key} = ?" for key in fields)
+        values = list(fields.values())
+        values.append(render_id)
+        await self._execute_write(
+            f"UPDATE openscad_renders SET {columns} WHERE id = ?", tuple(values)
+        )
+
+    async def get_render(self, render_id: str) -> Optional[Dict[str, Any]]:
+        row = await self._fetch_one(
+            "SELECT * FROM openscad_renders WHERE id = ?", [render_id]
+        )
+        if row and row.get("parameters"):
+            row["parameters"] = json.loads(row["parameters"])
+        return row
+
+    # ---- Presets -----------------------------------------------------------
+
+    async def create_preset(self, preset: Dict[str, Any]) -> None:
+        await self._execute_write(
+            """
+            INSERT INTO openscad_presets (id, template_id, name, parameters)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                preset["id"],
+                preset["template_id"],
+                preset["name"],
+                json.dumps(preset.get("parameters", {})),
+            ),
+        )
+
+    async def list_presets(self, template_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        if template_id:
+            rows = await self._fetch_all(
+                "SELECT * FROM openscad_presets WHERE template_id = ? ORDER BY created_at DESC",
+                [template_id],
+            )
+        else:
+            rows = await self._fetch_all(
+                "SELECT * FROM openscad_presets ORDER BY created_at DESC"
+            )
+        for row in rows:
+            if row.get("parameters"):
+                row["parameters"] = json.loads(row["parameters"])
+        return rows
+
+    async def delete_preset(self, preset_id: str) -> None:
+        await self._execute_write(
+            "DELETE FROM openscad_presets WHERE id = ?", (preset_id,)
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.31.0")
+APP_VERSION = get_version(fallback="2.32.0")
 
 
 # Prometheus metrics - initialized once

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,7 @@ from src.api.routers.logs import router as logs_router
 from src.api.routers.orders import router as orders_router
 from src.api.routers.customers import router as customers_router
 from src.api.routers.order_sources import router as order_sources_router
+from src.api.routers.generator import router as generator_router
 from src.database.database import Database
 from src.services.event_service import EventService
 from src.services.config_service import ConfigService
@@ -315,6 +316,21 @@ async def lifespan(app: FastAPI):
     timer.end("Slicer services initialization")
     logger.info("[OK] Slicer services initialized")
 
+    # Initialize OpenSCAD generator service (optional - degrades if binary absent)
+    timer.start("Generator service initialization")
+    logger.info("Initializing OpenSCAD generator service...")
+    from src.services.openscad_service import OpenSCADService
+    from src.services.generator_service import GeneratorService
+
+    openscad_service = OpenSCADService()
+    generator_service = GeneratorService(
+        database, event_service, openscad_service, library_service=library_service
+    )
+    await generator_service.initialize()
+    timer.end("Generator service initialization")
+    logger.info("[OK] OpenSCAD generator service initialized",
+                openscad_available=openscad_service.available)
+
     app.state.config_service = config_service
     app.state.event_service = event_service
     app.state.job_service = job_service
@@ -332,6 +348,8 @@ async def lifespan(app: FastAPI):
     app.state.camera_snapshot_service = camera_snapshot_service
     app.state.slicer_service = slicer_service
     app.state.slicing_queue = slicing_queue
+    app.state.openscad_service = openscad_service
+    app.state.generator_service = generator_service
 
     # Initialize notification service
     notification_service = NotificationService(database, event_service)
@@ -758,6 +776,7 @@ def create_application() -> FastAPI:
     app.include_router(orders_router, prefix="/api/v1/orders", tags=["Orders"])
     app.include_router(customers_router, prefix="/api/v1/customers", tags=["Customers"])
     app.include_router(order_sources_router, prefix="/api/v1/order-sources", tags=["Order Sources"])
+    app.include_router(generator_router, prefix="/api/v1/generator", tags=["OpenSCAD Generator"])
     app.include_router(websocket_router, prefix="/ws", tags=["WebSocket"])
     # Temporary debug endpoints (remove before production if not needed)
     app.include_router(debug_router, prefix="/api/v1/debug", tags=["Debug"])

--- a/src/models/generator.py
+++ b/src/models/generator.py
@@ -1,0 +1,103 @@
+"""
+Data models for the OpenSCAD generator module.
+
+These models describe parametric OpenSCAD templates, their auto-discovered
+parameters (via the OpenSCAD Customizer comment syntax), render requests and
+results, and the runtime availability status of the OpenSCAD binary.
+"""
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ScadParameterType(str, Enum):
+    """Supported OpenSCAD Customizer parameter types."""
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    STRING = "string"
+    ENUM = "enum"
+
+
+class RenderFormat(str, Enum):
+    """Supported render output formats."""
+    STL = "stl"
+    PNG = "png"
+
+
+class RenderStatus(str, Enum):
+    """Lifecycle status of a render job."""
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ScadParameter(BaseModel):
+    """A single parameter discovered from an OpenSCAD script."""
+    name: str
+    type: ScadParameterType
+    default: Any = None
+    description: Optional[str] = None
+    group: Optional[str] = None
+    # Numeric constraints (Customizer: // [min:max] or // [min:step:max])
+    min: Optional[float] = None
+    max: Optional[float] = None
+    step: Optional[float] = None
+    # Enum/dropdown options (Customizer: // [a, b, c])
+    options: Optional[List[Any]] = None
+
+
+class ScadTemplate(BaseModel):
+    """A bundled or uploaded OpenSCAD template/source."""
+    id: str
+    name: str
+    description: Optional[str] = None
+    category: Optional[str] = None
+    # True for app-bundled generators, False for user uploads
+    bundled: bool = True
+    parameters: List[ScadParameter] = Field(default_factory=list)
+    # Default camera string for PNG previews: "tx,ty,tz,rx,ry,rz,dist"
+    default_camera: Optional[str] = None
+    source: Optional[str] = None  # raw .scad source (omitted from list views)
+
+
+class RenderRequest(BaseModel):
+    """Request to render a template/source with parameter overrides."""
+    source_ref: str = Field(..., description="Template id or uploaded source id")
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    format: RenderFormat = RenderFormat.STL
+
+
+class RenderResult(BaseModel):
+    """Result of a render operation."""
+    render_id: str
+    source_ref: str
+    format: RenderFormat
+    status: RenderStatus
+    preview_url: Optional[str] = None
+    model_url: Optional[str] = None
+    error: Optional[str] = None
+
+
+class GeneratorStatus(BaseModel):
+    """Runtime availability of the OpenSCAD generator."""
+    available: bool
+    version: Optional[str] = None
+    path: Optional[str] = None
+
+
+class PresetRequest(BaseModel):
+    """Request to save a named parameter preset for a template."""
+    template_id: str
+    name: str
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Preset(BaseModel):
+    """A saved named parameter set for a template."""
+    id: str
+    template_id: str
+    name: str
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    created_at: Optional[str] = None

--- a/src/scad_templates/box.json
+++ b/src/scad_templates/box.json
@@ -1,0 +1,6 @@
+{
+  "name": "Parametric Box",
+  "description": "A rectangular box with configurable dimensions, wall thickness and rounded corners.",
+  "category": "Containers",
+  "default_camera": "40,30,20,60,0,30,360"
+}

--- a/src/scad_templates/box.scad
+++ b/src/scad_templates/box.scad
@@ -1,0 +1,45 @@
+// Parametric Box Generator
+// A configurable rectangular box with optional lid recess and rounded corners.
+
+/* [Dimensions] */
+// Inner width (mm)
+width = 80;            // [20:300]
+// Inner depth (mm)
+depth = 60;            // [20:300]
+// Inner height (mm)
+height = 40;           // [10:300]
+// Wall thickness (mm)
+wall_thickness = 2;    // [1:0.5:8]
+
+/* [Style] */
+// Corner rounding radius (mm, 0 = sharp)
+corner_radius = 3;     // [0:0.5:20]
+// Add a solid bottom
+closed_bottom = true;
+
+/* [Quality] */
+$fn = 48;              // [12:4:120]
+
+module rounded_box(w, d, h, r) {
+    if (r <= 0) {
+        cube([w, d, h]);
+    } else {
+        hull() {
+            for (x = [r, w - r], y = [r, d - r])
+                translate([x, y, 0]) cylinder(h = h, r = r);
+        }
+    }
+}
+
+module box() {
+    outer_w = width + 2 * wall_thickness;
+    outer_d = depth + 2 * wall_thickness;
+    outer_h = height + (closed_bottom ? wall_thickness : 0);
+    difference() {
+        rounded_box(outer_w, outer_d, outer_h, corner_radius);
+        translate([wall_thickness, wall_thickness, closed_bottom ? wall_thickness : -1])
+            rounded_box(width, depth, height + 1, max(0, corner_radius - wall_thickness));
+    }
+}
+
+box();

--- a/src/scad_templates/vase.json
+++ b/src/scad_templates/vase.json
@@ -1,0 +1,6 @@
+{
+  "name": "Parametric Vase",
+  "description": "A round vase with configurable taper, twist, faceting and wall thickness.",
+  "category": "Containers",
+  "default_camera": "0,0,60,60,0,30,420"
+}

--- a/src/scad_templates/vase.scad
+++ b/src/scad_templates/vase.scad
@@ -1,0 +1,59 @@
+// Parametric Vase Generator
+// A configurable round vase with optional twist and faceting.
+
+/* [Dimensions] */
+// Total height of the vase (mm)
+height = 120;          // [40:300]
+// Radius at the base (mm)
+base_radius = 40;      // [15:120]
+// Radius at the top opening (mm)
+top_radius = 30;       // [10:120]
+// Wall thickness (mm)
+wall_thickness = 2;    // [0.8:0.2:6]
+
+/* [Style] */
+// Twist applied over the full height (degrees)
+twist = 60;            // [0:360]
+// Number of sides (low values give a faceted look)
+sides = 64;            // [3, 6, 8, 12, 24, 48, 64, 128]
+// Add a solid closed bottom
+closed_bottom = true;
+
+/* [Quality] */
+// Curve smoothness
+$fn = 64;              // [16:8:200]
+
+module vase() {
+    difference() {
+        // Outer body
+        linear_extrude(height = height, twist = twist, slices = max(1, height))
+            circle(r = base_radius, $fn = sides);
+
+        // Hollow interior (leave wall_thickness)
+        translate([0, 0, closed_bottom ? wall_thickness : -1])
+            linear_extrude(
+                height = height - (closed_bottom ? wall_thickness : 0) + 1,
+                twist = twist,
+                slices = max(1, height))
+                circle(r = base_radius - wall_thickness, $fn = sides);
+    }
+}
+
+// Scale the top to create taper from base_radius to top_radius.
+module tapered_vase() {
+    scale_top = top_radius / base_radius;
+    // Approximate taper using a hull of base and top profiles is expensive;
+    // a simple linear_extrude with scale gives a clean cone-like taper.
+    difference() {
+        linear_extrude(height = height, twist = twist, scale = scale_top,
+                       slices = max(1, height))
+            circle(r = base_radius, $fn = sides);
+        translate([0, 0, closed_bottom ? wall_thickness : -1])
+            linear_extrude(
+                height = height - (closed_bottom ? wall_thickness : 0) + 1,
+                twist = twist, scale = scale_top, slices = max(1, height))
+                circle(r = base_radius - wall_thickness, $fn = sides);
+    }
+}
+
+tapered_vase();

--- a/src/services/generator_service.py
+++ b/src/services/generator_service.py
@@ -1,0 +1,261 @@
+"""
+Generator service for the OpenSCAD module.
+
+Coordinates bundled/curated generator templates and arbitrary uploaded ``.scad``
+files: discovers their parameters, renders them to STL/PNG via OpenSCADService,
+tracks render artifacts, hands finished models off to the Library, and stores
+named parameter presets.
+"""
+import json
+import shutil
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import structlog
+
+from src.database.repositories import OpenSCADRepository
+from src.models.generator import (
+    GeneratorStatus,
+    Preset,
+    RenderResult,
+    ScadParameter,
+    ScadTemplate,
+)
+from src.services.openscad_service import OpenSCADService
+from src.services.scad_parser import parse_parameters
+from src.utils.config import get_settings
+from src.utils.errors import GeneratorTemplateNotFoundError, OpenSCADRenderError
+
+logger = structlog.get_logger(__name__)
+
+UPLOAD_PREFIX = "upload:"
+
+
+class GeneratorService:
+    """Coordinator for OpenSCAD template rendering and management."""
+
+    def __init__(self, database, event_service, openscad_service: OpenSCADService,
+                 library_service=None):
+        self.database = database
+        self.event_service = event_service
+        self.openscad = openscad_service
+        self.library_service = library_service
+        self.repo = OpenSCADRepository(database._connection)
+
+        settings = get_settings()
+        self.output_dir = Path(settings.generator_output_dir)
+        self.uploads_dir = self.output_dir / "uploads"
+        self.renders_dir = self.output_dir / "renders"
+        self.templates_dir = Path(__file__).parent.parent / "scad_templates"
+
+        self._templates: Dict[str, ScadTemplate] = {}
+
+    async def initialize(self) -> None:
+        """Create working directories and load bundled templates."""
+        for folder in (self.output_dir, self.uploads_dir, self.renders_dir):
+            folder.mkdir(parents=True, exist_ok=True)
+        self._load_templates()
+        logger.info("Generator service initialized",
+                    templates=len(self._templates),
+                    openscad_available=self.openscad.available)
+
+    # ---- Status ------------------------------------------------------------
+
+    def get_status(self) -> GeneratorStatus:
+        return GeneratorStatus(**self.openscad.get_status())
+
+    # ---- Templates ---------------------------------------------------------
+
+    def _load_templates(self) -> None:
+        """Load bundled .scad templates and their optional .json metadata."""
+        self._templates.clear()
+        if not self.templates_dir.exists():
+            return
+        for scad_file in sorted(self.templates_dir.glob("*.scad")):
+            template_id = scad_file.stem
+            source = scad_file.read_text(encoding="utf-8")
+            meta: Dict[str, Any] = {}
+            meta_file = scad_file.with_suffix(".json")
+            if meta_file.exists():
+                try:
+                    meta = json.loads(meta_file.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as e:
+                    logger.warning("Invalid template metadata", file=str(meta_file), error=str(e))
+            self._templates[template_id] = ScadTemplate(
+                id=template_id,
+                name=meta.get("name", template_id.replace("_", " ").title()),
+                description=meta.get("description"),
+                category=meta.get("category"),
+                bundled=True,
+                parameters=parse_parameters(source),
+                default_camera=meta.get("default_camera"),
+                source=source,
+            )
+
+    def list_templates(self) -> List[ScadTemplate]:
+        """Return all bundled templates (with parameters, without source)."""
+        return [t.model_copy(update={"source": None}) for t in self._templates.values()]
+
+    def get_template(self, template_id: str) -> ScadTemplate:
+        template = self._templates.get(template_id)
+        if not template:
+            raise GeneratorTemplateNotFoundError(template_id)
+        return template
+
+    def parse_source(self, source: str) -> List[ScadParameter]:
+        """Parse parameters from arbitrary OpenSCAD source."""
+        return parse_parameters(source)
+
+    # ---- Uploads -----------------------------------------------------------
+
+    def store_upload(self, source: str, filename: Optional[str] = None) -> ScadTemplate:
+        """Persist an uploaded .scad source and return it as a template."""
+        upload_id = uuid.uuid4().hex[:12]
+        path = self.uploads_dir / f"{upload_id}.scad"
+        path.write_text(source, encoding="utf-8")
+        return ScadTemplate(
+            id=f"{UPLOAD_PREFIX}{upload_id}",
+            name=filename or f"Uploaded {upload_id}",
+            description="Uploaded OpenSCAD file",
+            category="Uploads",
+            bundled=False,
+            parameters=parse_parameters(source),
+            source=source,
+        )
+
+    def _resolve_source(self, source_ref: str) -> tuple[str, Optional[str]]:
+        """Return (source, default_camera) for a template id or upload ref."""
+        if source_ref.startswith(UPLOAD_PREFIX):
+            upload_id = source_ref[len(UPLOAD_PREFIX):]
+            path = self.uploads_dir / f"{upload_id}.scad"
+            if not path.exists():
+                raise GeneratorTemplateNotFoundError(source_ref)
+            return path.read_text(encoding="utf-8"), None
+        template = self.get_template(source_ref)
+        return template.source or "", template.default_camera
+
+    # ---- Rendering ---------------------------------------------------------
+
+    async def render(self, source_ref: str, parameters: Dict[str, Any],
+                     fmt: str = "stl") -> RenderResult:
+        """Render a template/upload to STL or PNG and record the artifact."""
+        source, default_camera = self._resolve_source(source_ref)
+        render_id = uuid.uuid4().hex[:16]
+        work_dir = self.renders_dir / render_id
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        await self.repo.create_render({
+            "id": render_id,
+            "source_ref": source_ref,
+            "parameters": parameters,
+            "format": fmt,
+            "status": "running",
+            "work_dir": str(work_dir),
+        })
+        await self._emit("started", render_id, source_ref)
+
+        try:
+            scad_path = work_dir / "model.scad"
+            scad_path.write_text(source, encoding="utf-8")
+            output_path = work_dir / f"model.{fmt}"
+            await self.openscad.render(
+                scad_path, output_path, params=parameters, fmt=fmt, camera=default_camera
+            )
+        except OpenSCADRenderError as e:
+            await self.repo.update_render(render_id, {"status": "failed", "error": e.message})
+            await self._emit("failed", render_id, source_ref, error=e.message)
+            raise
+
+        field = "model_path" if fmt == "stl" else "preview_path"
+        await self.repo.update_render(render_id, {"status": "completed", field: str(output_path)})
+        await self._emit("completed", render_id, source_ref)
+
+        return RenderResult(
+            render_id=render_id,
+            source_ref=source_ref,
+            format=fmt,
+            status="completed",
+            model_url=f"/api/v1/generator/render/{render_id}/model.stl" if fmt == "stl" else None,
+            preview_url=f"/api/v1/generator/render/{render_id}/preview.png" if fmt == "png" else None,
+        )
+
+    async def get_artifact_path(self, render_id: str, kind: str) -> Optional[Path]:
+        """Return the filesystem path to a render artifact ('model' or 'preview')."""
+        render = await self.repo.get_render(render_id)
+        if not render:
+            return None
+        key = "model_path" if kind == "model" else "preview_path"
+        path_str = render.get(key)
+        if path_str and Path(path_str).exists():
+            return Path(path_str)
+        return None
+
+    # ---- Library hand-off --------------------------------------------------
+
+    async def save_to_library(self, render_id: str,
+                              display_name: Optional[str] = None) -> Dict[str, Any]:
+        """Copy a completed STL render into the Library so it can be sliced."""
+        if not self.library_service:
+            raise OpenSCADRenderError("Library service unavailable")
+        render = await self.repo.get_render(render_id)
+        if not render:
+            raise GeneratorTemplateNotFoundError(render_id)
+        model_path = render.get("model_path")
+        if not model_path or not Path(model_path).exists():
+            raise OpenSCADRenderError("No STL artifact to save", details={"render_id": render_id})
+
+        name = display_name or f"{render['source_ref']}_{render_id[:8]}"
+        named_path = Path(model_path).parent / f"{_safe_filename(name)}.stl"
+        if named_path != Path(model_path):
+            shutil.copy2(model_path, named_path)
+
+        source_info = {
+            "type": "upload",
+            "generator": "openscad",
+            "source_ref": render["source_ref"],
+            "parameters": render.get("parameters", {}),
+        }
+        return await self.library_service.add_file_to_library(
+            source_path=named_path, source_info=source_info,
+            copy_file=True, calculate_hash=True,
+        )
+
+    # ---- Presets -----------------------------------------------------------
+
+    async def save_preset(self, template_id: str, name: str,
+                          parameters: Dict[str, Any]) -> Preset:
+        preset_id = uuid.uuid4().hex[:12]
+        await self.repo.create_preset({
+            "id": preset_id, "template_id": template_id,
+            "name": name, "parameters": parameters,
+        })
+        return Preset(id=preset_id, template_id=template_id, name=name,
+                      parameters=parameters, created_at=datetime.now().isoformat())
+
+    async def list_presets(self, template_id: Optional[str] = None) -> List[Preset]:
+        rows = await self.repo.list_presets(template_id)
+        return [Preset(**row) for row in rows]
+
+    async def delete_preset(self, preset_id: str) -> None:
+        await self.repo.delete_preset(preset_id)
+
+    # ---- Events ------------------------------------------------------------
+
+    async def _emit(self, phase: str, render_id: str, source_ref: str,
+                    error: Optional[str] = None) -> None:
+        payload = {
+            "render_id": render_id,
+            "source_ref": source_ref,
+            "timestamp": datetime.now().isoformat(),
+        }
+        if error:
+            payload["error"] = error
+        await self.event_service.emit_event(f"openscad.generation.{phase}", payload)
+
+
+def _safe_filename(name: str) -> str:
+    """Sanitize a string for use as a filename stem."""
+    keep = [c if (c.isalnum() or c in (" ", "-", "_")) else "_" for c in name]
+    return "".join(keep).strip().replace(" ", "_")[:80] or "model"

--- a/src/services/openscad_service.py
+++ b/src/services/openscad_service.py
@@ -1,0 +1,207 @@
+"""
+OpenSCAD CLI wrapper.
+
+OpenSCAD is an external binary (unlike the trimesh/numpy-stl Python stack used
+elsewhere), so this service shells out to it. Rendering runs in a thread pool
+executor with a timeout, mirroring ``PreviewRenderService``. The binary is
+treated as an optional dependency: the service detects availability on init and
+the rest of the application degrades gracefully when it is missing.
+"""
+import asyncio
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import structlog
+
+from src.utils.config import get_settings
+from src.utils.errors import OpenSCADNotAvailableError, OpenSCADRenderError
+
+logger = structlog.get_logger(__name__)
+
+# Default camera for PNG previews: translate(x,y,z), rotate(x,y,z), distance.
+DEFAULT_CAMERA = "0,0,0,55,0,25,140"
+DEFAULT_IMGSIZE = (600, 600)
+
+
+class OpenSCADService:
+    """Thin wrapper around the OpenSCAD command-line binary."""
+
+    def __init__(self):
+        settings = get_settings()
+        self._timeout = settings.openscad_render_timeout
+        self._max_output_bytes = settings.openscad_max_output_mb * 1024 * 1024
+        self._configured_path = settings.openscad_binary_path
+        self._binary: Optional[str] = None
+        self._version: Optional[str] = None
+        self._available = False
+        self.detect()
+
+    def detect(self) -> bool:
+        """Locate the OpenSCAD binary and cache its version. Returns availability."""
+        binary = self._configured_path or shutil.which("openscad")
+        if not binary or not Path(binary).exists():
+            self._available = False
+            self._binary = None
+            logger.info("OpenSCAD not available; generator module disabled",
+                        configured_path=self._configured_path)
+            return False
+
+        self._binary = binary
+        # If no X server is present, OpenSCAD needs a virtual framebuffer for PNG.
+        self._xvfb = shutil.which("xvfb-run")
+        try:
+            result = subprocess.run(
+                [binary, "--version"],
+                capture_output=True, text=True, timeout=15
+            )
+            # OpenSCAD prints the version to stderr.
+            output = (result.stderr or result.stdout or "").strip()
+            self._version = output.replace("OpenSCAD version", "").strip() or output
+            self._available = True
+            logger.info("OpenSCAD detected", path=binary, version=self._version)
+        except Exception as e:  # noqa: BLE001 - any failure means unusable
+            self._available = False
+            self._binary = None
+            logger.warning("OpenSCAD found but not runnable", path=binary, error=str(e))
+        return self._available
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    @property
+    def version(self) -> Optional[str]:
+        return self._version
+
+    @property
+    def path(self) -> Optional[str]:
+        return self._binary
+
+    def _require_available(self) -> None:
+        if not self._available:
+            raise OpenSCADNotAvailableError(details={"configured_path": self._configured_path})
+
+    @staticmethod
+    def serialize_value(value: Any) -> str:
+        """Serialize a Python value to an OpenSCAD ``-D`` literal."""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        if isinstance(value, (list, tuple)):
+            return "[" + ",".join(OpenSCADService.serialize_value(v) for v in value) + "]"
+        # Strings: quote and escape.
+        escaped = str(value).replace("\\", "\\\\").replace("\"", "\\\"")
+        return f"\"{escaped}\""
+
+    def _build_command(
+        self,
+        scad_path: Path,
+        output_path: Path,
+        params: Dict[str, Any],
+        fmt: str,
+        camera: Optional[str],
+    ) -> List[str]:
+        cmd: List[str] = [self._binary, "-o", str(output_path)]
+        if fmt == "png":
+            cmd += [
+                "--camera", camera or DEFAULT_CAMERA,
+                "--imgsize", f"{DEFAULT_IMGSIZE[0]},{DEFAULT_IMGSIZE[1]}",
+                "--colorscheme", "Tomorrow",
+                "--render",
+            ]
+        for key, value in params.items():
+            cmd += ["-D", f"{key}={self.serialize_value(value)}"]
+        cmd.append(str(scad_path))
+        if fmt == "png" and getattr(self, "_xvfb", None):
+            # Wrap with virtual framebuffer for headless PNG rendering.
+            cmd = [self._xvfb, "-a", "--server-args=-screen 0 800x600x24"] + cmd
+        return cmd
+
+    async def render(
+        self,
+        scad_path: Path,
+        output_path: Path,
+        params: Optional[Dict[str, Any]] = None,
+        fmt: str = "stl",
+        camera: Optional[str] = None,
+    ) -> Path:
+        """
+        Render an OpenSCAD file to ``output_path`` (``stl`` or ``png``).
+
+        Runs in an executor with a timeout and enforces an output-size cap.
+        Raises OpenSCADNotAvailableError / OpenSCADRenderError on failure.
+        """
+        self._require_available()
+        params = params or {}
+        loop = asyncio.get_event_loop()
+        cmd = self._build_command(scad_path, output_path, params, fmt, camera)
+        logger.info("Running OpenSCAD render", fmt=fmt, output=str(output_path))
+        try:
+            await asyncio.wait_for(
+                loop.run_in_executor(None, self._run, cmd),
+                timeout=self._timeout + 10,
+            )
+        except asyncio.TimeoutError:
+            raise OpenSCADRenderError("render timed out", details={"timeout": self._timeout})
+
+        if not output_path.exists():
+            raise OpenSCADRenderError("no output produced")
+        size = output_path.stat().st_size
+        if size == 0:
+            raise OpenSCADRenderError("empty output produced")
+        if size > self._max_output_bytes:
+            output_path.unlink(missing_ok=True)
+            raise OpenSCADRenderError(
+                "output exceeds size limit",
+                details={"size_mb": round(size / (1024 * 1024), 1)},
+            )
+        return output_path
+
+    def _run(self, cmd: List[str]) -> None:
+        """Blocking subprocess invocation (executed in a thread pool)."""
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=self._timeout
+            )
+        except subprocess.TimeoutExpired:
+            raise OpenSCADRenderError("render timed out", details={"timeout": self._timeout})
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            # Keep the message compact; surface the most relevant line.
+            reason = stderr.splitlines()[-1] if stderr else f"exit code {result.returncode}"
+            logger.warning("OpenSCAD render failed", returncode=result.returncode, stderr=stderr[:500])
+            raise OpenSCADRenderError(reason, details={"returncode": result.returncode})
+
+    async def render_to_temp(
+        self,
+        source: str,
+        params: Optional[Dict[str, Any]] = None,
+        fmt: str = "stl",
+        camera: Optional[str] = None,
+        work_dir: Optional[Path] = None,
+    ) -> Tuple[Path, Path]:
+        """
+        Write ``source`` to an isolated working dir and render it.
+
+        Returns (scad_path, output_path). The caller owns cleanup of work_dir.
+        """
+        self._require_available()
+        base = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="openscad_"))
+        base.mkdir(parents=True, exist_ok=True)
+        scad_path = base / "model.scad"
+        scad_path.write_text(source, encoding="utf-8")
+        output_path = base / f"model.{fmt}"
+        await self.render(scad_path, output_path, params=params, fmt=fmt, camera=camera)
+        return scad_path, output_path
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return availability info for the status endpoint."""
+        return {
+            "available": self._available,
+            "version": self._version,
+            "path": self._binary,
+        }

--- a/src/services/scad_parser.py
+++ b/src/services/scad_parser.py
@@ -1,0 +1,211 @@
+"""
+OpenSCAD Customizer parameter parser.
+
+Extracts the tweakable parameters from an OpenSCAD script by reading top-level
+variable assignments and their Customizer annotations, producing a structured
+schema that drives a dynamic frontend form. Works for both bundled generator
+templates and arbitrary uploaded ``.scad`` files.
+
+Customizer syntax supported (https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Customizer):
+    /* [Group Name] */          section header (groups following parameters)
+    /* [Hidden] */              hides following parameters from the customizer
+    // description              description on the line above a parameter
+    var = 10;   // [0:100]      number slider with min/max
+    var = 2;    // [0:0.5:10]   number slider with min/step/max
+    var = "a";  // [a, b, c]    dropdown of values
+    var = 10;   // [10:L, 20:M] labeled dropdown (value:label)
+    var = true;                 boolean checkbox
+    var = "text";               free string
+"""
+import re
+from typing import Any, List, Optional
+
+from src.models.generator import ScadParameter, ScadParameterType
+
+# Keywords / statement starters that are never parameters.
+_NON_PARAM_STARTERS = (
+    "module", "function", "include", "use", "for", "if", "else",
+    "echo", "assert", "let", "intersection_for",
+)
+
+# Top-level assignment: identifier = value ; (value captured non-greedily up to ;)
+_ASSIGN_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*(.+?);\s*(?://(.*))?$")
+# Section header comment: /* [Name] */
+_SECTION_RE = re.compile(r"/\*\s*\[(.+?)\]\s*\*/")
+# Customizer widget bracket inside a trailing comment: [ ... ]
+_BRACKET_RE = re.compile(r"\[(.+?)\]")
+
+
+def _is_number(token: str) -> bool:
+    try:
+        float(token)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _coerce_number(token: str) -> float:
+    value = float(token)
+    return int(value) if value.is_integer() else value
+
+
+def _parse_default(raw: str) -> Any:
+    """Parse an OpenSCAD literal default value into a Python value."""
+    raw = raw.strip()
+    if raw in ("true", "false"):
+        return raw == "true"
+    if (len(raw) >= 2) and raw[0] == raw[-1] and raw[0] in ("\"", "'"):
+        return raw[1:-1]
+    if _is_number(raw):
+        return _coerce_number(raw)
+    return raw  # vectors/expressions left as-is
+
+
+def _strip_code(line: str) -> str:
+    """Return the code portion of a line (drop trailing // comment, inline /* */)."""
+    line = re.sub(r"/\*.*?\*/", "", line)
+    idx = line.find("//")
+    if idx != -1:
+        line = line[:idx]
+    return line
+
+
+def _parse_bracket(content: str):
+    """
+    Interpret a Customizer bracket's content.
+
+    Returns a tuple (kind, data) where kind is 'range' or 'enum'.
+      range -> {'min','max','step'}
+      enum  -> [options]
+    """
+    content = content.strip()
+    if "," not in content:
+        # No comma: a numeric range like 0:100 or 0:5:100, otherwise a single option.
+        parts = [p.strip() for p in content.split(":")]
+        if len(parts) in (2, 3) and all(_is_number(p) for p in parts):
+            if len(parts) == 2:
+                return "range", {"min": _coerce_number(parts[0]),
+                                 "max": _coerce_number(parts[1]), "step": None}
+            return "range", {"min": _coerce_number(parts[0]),
+                             "step": _coerce_number(parts[1]),
+                             "max": _coerce_number(parts[2])}
+        return "enum", [_option_value(content)]
+    # Comma separated -> dropdown of options (values may be 'value:label').
+    return "enum", [_option_value(p.strip()) for p in content.split(",")]
+
+
+def _option_value(token: str) -> Any:
+    """Extract the value from a dropdown option token ('value' or 'value:label')."""
+    value = token.split(":", 1)[0].strip()
+    return _coerce_number(value) if _is_number(value) else value
+
+
+def _infer_type(default: Any, bracket_kind: Optional[str]) -> ScadParameterType:
+    if bracket_kind == "enum":
+        return ScadParameterType.ENUM
+    if bracket_kind == "range":
+        return ScadParameterType.NUMBER
+    if isinstance(default, bool):
+        return ScadParameterType.BOOLEAN
+    if isinstance(default, (int, float)):
+        return ScadParameterType.NUMBER
+    return ScadParameterType.STRING
+
+
+def parse_parameters(source: str) -> List[ScadParameter]:
+    """
+    Parse OpenSCAD source and return its top-level Customizer parameters.
+
+    Only assignments at brace-depth 0 are considered (variables inside modules
+    or functions are ignored, matching OpenSCAD's own Customizer behaviour).
+    """
+    parameters: List[ScadParameter] = []
+    seen: set = set()
+    depth = 0
+    in_block_comment = False
+    current_group: Optional[str] = None
+    hidden = False
+    pending_description: Optional[str] = None
+
+    for raw_line in source.splitlines():
+        line = raw_line.rstrip("\n")
+
+        # Section headers are detected even within block-comment handling.
+        section = _SECTION_RE.search(line)
+        if section:
+            name = section.group(1).strip()
+            if name.lower() == "hidden":
+                hidden = True
+                current_group = None
+            else:
+                hidden = False
+                current_group = name
+            pending_description = None
+            continue
+
+        # Track multi-line block comments (so braces inside them are ignored).
+        if in_block_comment:
+            if "*/" in line:
+                in_block_comment = False
+                line = line.split("*/", 1)[1]
+            else:
+                continue
+
+        stripped = line.strip()
+
+        # Standalone line comment -> candidate description for the next parameter.
+        if stripped.startswith("//"):
+            pending_description = stripped[2:].strip() or None
+            continue
+
+        code = _strip_code(line)
+
+        if depth == 0 and not hidden:
+            match = _ASSIGN_RE.match(line)
+            if match:
+                name, raw_value, trailing = match.group(1), match.group(2), match.group(3)
+                first_token = code.strip().split()[0] if code.strip() else ""
+                if name not in _NON_PARAM_STARTERS and first_token == name and name not in seen:
+                    bracket_kind, bracket_data = None, None
+                    description = pending_description
+                    if trailing:
+                        bracket_match = _BRACKET_RE.search(trailing)
+                        if bracket_match:
+                            bracket_kind, bracket_data = _parse_bracket(bracket_match.group(1))
+                            # Any text before the bracket is an inline description.
+                            inline = trailing[:bracket_match.start()].strip()
+                            description = description or (inline or None)
+                        else:
+                            description = description or (trailing.strip() or None)
+
+                    default = _parse_default(raw_value)
+                    param = ScadParameter(
+                        name=name,
+                        type=_infer_type(default, bracket_kind),
+                        default=default,
+                        description=description,
+                        group=current_group,
+                    )
+                    if bracket_kind == "range":
+                        param.min = bracket_data["min"]
+                        param.max = bracket_data["max"]
+                        param.step = bracket_data["step"]
+                    elif bracket_kind == "enum":
+                        param.options = bracket_data
+
+                    parameters.append(param)
+                    seen.add(name)
+
+        # Update brace depth using only the code portion (strings approximated).
+        if "/*" in code and "*/" not in code:
+            in_block_comment = True
+            code = code.split("/*", 1)[0]
+        depth += code.count("{") - code.count("}")
+        if depth < 0:
+            depth = 0
+
+        # A non-comment, non-blank line consumes any pending description.
+        if stripped:
+            pending_description = None
+
+    return parameters

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -256,6 +256,33 @@ class PrinternizerSettings(BaseSettings):
         le=300
     )
 
+    # OpenSCAD Generator Configuration
+    openscad_binary_path: Optional[str] = Field(
+        default=None,
+        env="OPENSCAD_BINARY_PATH",
+        description="Path to the OpenSCAD binary. If unset, the binary is auto-detected on PATH. "
+                    "The generator module is optional and disabled when OpenSCAD is not available."
+    )
+    openscad_render_timeout: int = Field(
+        default=120,
+        env="OPENSCAD_RENDER_TIMEOUT",
+        description="Timeout in seconds for OpenSCAD render operations. Must be between 5 and 600 seconds.",
+        ge=5,
+        le=600
+    )
+    openscad_max_output_mb: int = Field(
+        default=100,
+        env="OPENSCAD_MAX_OUTPUT_MB",
+        description="Maximum allowed size (in MB) for an OpenSCAD render artifact. Guards against runaway uploads.",
+        ge=1,
+        le=2048
+    )
+    generator_output_dir: str = Field(
+        default="/data/printernizer/generator",
+        env="GENERATOR_OUTPUT_DIR",
+        description="Directory for OpenSCAD generator working files, render artifacts and uploaded scripts."
+    )
+
     # Library System Configuration
     library_enabled: bool = Field(
         default=True,

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -515,6 +515,74 @@ class LibraryItemNotFoundError(PrinternizerError):
 
 
 # =============================================================================
+# OpenSCAD Generator Errors
+# =============================================================================
+
+class OpenSCADNotAvailableError(PrinternizerError):
+    """OpenSCAD binary is not installed or could not be found."""
+
+    def __init__(self, details: Optional[Dict[str, Any]] = None):
+        """
+        Initialize OpenSCADNotAvailableError.
+
+        Args:
+            details: Additional context (e.g. configured path)
+        """
+        super().__init__(
+            message="OpenSCAD is not available. Install OpenSCAD or set OPENSCAD_BINARY_PATH "
+                    "to enable the model generator.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            error_code="OPENSCAD_NOT_AVAILABLE",
+            details=details or {}
+        )
+
+
+class OpenSCADRenderError(PrinternizerError):
+    """OpenSCAD render operation failed."""
+
+    def __init__(self, reason: str, details: Optional[Dict[str, Any]] = None):
+        """
+        Initialize OpenSCADRenderError.
+
+        Args:
+            reason: Failure reason (often captured from OpenSCAD stderr)
+            details: Additional context
+        """
+        error_details = {"reason": reason}
+        if details:
+            error_details.update(details)
+
+        super().__init__(
+            message=f"OpenSCAD render failed: {reason}",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error_code="OPENSCAD_RENDER_FAILED",
+            details=error_details
+        )
+
+
+class GeneratorTemplateNotFoundError(PrinternizerError):
+    """Requested generator template does not exist."""
+
+    def __init__(self, template_id: str, details: Optional[Dict[str, Any]] = None):
+        """
+        Initialize GeneratorTemplateNotFoundError.
+
+        Args:
+            template_id: ID of the template that wasn't found
+            details: Additional context
+        """
+        error_details = {"template_id": template_id}
+        if details:
+            error_details.update(details)
+
+        super().__init__(
+            message=f"Generator template not found: {template_id}",
+            status_code=status.HTTP_404_NOT_FOUND,
+            details=error_details
+        )
+
+
+# =============================================================================
 # General Errors
 # =============================================================================
 

--- a/tests/test_generator_service.py
+++ b/tests/test_generator_service.py
@@ -1,0 +1,105 @@
+"""Tests for the OpenSCAD GeneratorService (OpenSCAD binary mocked)."""
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from src.services.generator_service import GeneratorService
+from src.services.openscad_service import OpenSCADService
+
+MIGRATION = pathlib.Path("migrations/032_add_openscad_tables.sql").read_text()
+
+
+@pytest.fixture
+async def service(tmp_path, monkeypatch):
+    # Point generator output at a temp dir.
+    monkeypatch.setenv("GENERATOR_OUTPUT_DIR", str(tmp_path / "generator"))
+    from src.utils import config as config_module
+    config_module.reload_settings()
+
+    conn = await aiosqlite.connect(":memory:")
+    await conn.executescript(MIGRATION)
+    database = SimpleNamespace(_connection=conn)
+
+    event_service = SimpleNamespace(emit_event=AsyncMock())
+    openscad = OpenSCADService()
+    # Force "available" and stub the actual render to write a fake artifact.
+    openscad._available = True
+    openscad._binary = "/usr/bin/openscad"
+
+    async def fake_render(scad_path, output_path, params=None, fmt="stl", camera=None):
+        output_path.write_bytes(b"solid model\nendsolid model\n")
+        return output_path
+
+    openscad.render = fake_render
+
+    library_service = SimpleNamespace(
+        add_file_to_library=AsyncMock(return_value={"id": "lib_1", "status": "ready"})
+    )
+
+    svc = GeneratorService(database, event_service, openscad, library_service=library_service)
+    await svc.initialize()
+    yield svc
+    await conn.close()
+    config_module.reload_settings()
+
+
+async def test_bundled_templates_loaded(service):
+    templates = service.list_templates()
+    ids = {t.id for t in templates}
+    assert "vase" in ids
+    assert "box" in ids
+    # List view omits source but includes parameters.
+    vase = next(t for t in templates if t.id == "vase")
+    assert vase.source is None
+    assert any(p.name == "height" for p in vase.parameters)
+
+
+async def test_get_template_includes_source(service):
+    vase = service.get_template("vase")
+    assert vase.source and "linear_extrude" in vase.source
+
+
+def test_serialize_value():
+    assert OpenSCADService.serialize_value(True) == "true"
+    assert OpenSCADService.serialize_value(False) == "false"
+    assert OpenSCADService.serialize_value(5) == "5"
+    assert OpenSCADService.serialize_value("smooth") == '"smooth"'
+    assert OpenSCADService.serialize_value([1, 2, 3]) == "[1,2,3]"
+
+
+async def test_render_and_save_to_library(service):
+    result = await service.render("vase", {"height": 100}, fmt="stl")
+    assert result.status == "completed"
+    assert result.model_url.endswith("/model.stl")
+
+    # Artifact is retrievable.
+    path = await service.get_artifact_path(result.render_id, "model")
+    assert path is not None and path.exists()
+
+    # Save hands the file to the library service.
+    saved = await service.save_to_library(result.render_id, display_name="My Vase")
+    assert saved["id"] == "lib_1"
+    service.library_service.add_file_to_library.assert_awaited_once()
+
+    # Generation events were emitted.
+    assert service.event_service.emit_event.await_count >= 2
+
+
+async def test_presets_roundtrip(service):
+    preset = await service.save_preset("vase", "Tall", {"height": 250})
+    presets = await service.list_presets("vase")
+    assert any(p.id == preset.id and p.name == "Tall" for p in presets)
+    await service.delete_preset(preset.id)
+    assert await service.list_presets("vase") == []
+
+
+async def test_upload_roundtrip(service):
+    template = service.store_upload("height = 10; // [1:20]\n", filename="thing.scad")
+    assert template.id.startswith("upload:")
+    assert any(p.name == "height" for p in template.parameters)
+    # Uploaded source resolves for rendering.
+    result = await service.render(template.id, {"height": 12}, fmt="stl")
+    assert result.status == "completed"

--- a/tests/test_scad_parser.py
+++ b/tests/test_scad_parser.py
@@ -1,0 +1,126 @@
+"""Unit tests for the OpenSCAD Customizer parameter parser."""
+from src.models.generator import ScadParameterType
+from src.services.scad_parser import parse_parameters
+
+
+def _by_name(params):
+    return {p.name: p for p in params}
+
+
+def test_number_with_range():
+    params = _by_name(parse_parameters("height = 100; // [10:200]"))
+    p = params["height"]
+    assert p.type == ScadParameterType.NUMBER
+    assert p.default == 100
+    assert p.min == 10
+    assert p.max == 200
+    assert p.step is None
+
+
+def test_number_with_step_range():
+    params = _by_name(parse_parameters("wall = 2; // [0.5:0.5:5]"))
+    p = params["wall"]
+    assert p.type == ScadParameterType.NUMBER
+    assert p.min == 0.5
+    assert p.step == 0.5
+    assert p.max == 5
+
+
+def test_boolean():
+    params = _by_name(parse_parameters("faceted = true;"))
+    p = params["faceted"]
+    assert p.type == ScadParameterType.BOOLEAN
+    assert p.default is True
+
+
+def test_string():
+    params = _by_name(parse_parameters('label = "hello";'))
+    p = params["label"]
+    assert p.type == ScadParameterType.STRING
+    assert p.default == "hello"
+
+
+def test_string_dropdown():
+    params = _by_name(parse_parameters('style = "smooth"; // [smooth, faceted, ribbed]'))
+    p = params["style"]
+    assert p.type == ScadParameterType.ENUM
+    assert p.options == ["smooth", "faceted", "ribbed"]
+    assert p.default == "smooth"
+
+
+def test_numeric_dropdown():
+    params = _by_name(parse_parameters("segments = 6; // [3, 6, 12, 24]"))
+    p = params["segments"]
+    assert p.type == ScadParameterType.ENUM
+    assert p.options == [3, 6, 12, 24]
+
+
+def test_labeled_dropdown():
+    params = _by_name(parse_parameters("quality = 10; // [10:Low, 20:Medium, 30:High]"))
+    p = params["quality"]
+    assert p.type == ScadParameterType.ENUM
+    assert p.options == [10, 20, 30]
+
+
+def test_description_from_line_above():
+    src = "// The total height in mm\nheight = 100;"
+    p = _by_name(parse_parameters(src))["height"]
+    assert p.description == "The total height in mm"
+
+
+def test_groups():
+    src = """
+/* [Dimensions] */
+height = 100;
+width = 50;
+
+/* [Style] */
+twist = 30;
+"""
+    params = _by_name(parse_parameters(src))
+    assert params["height"].group == "Dimensions"
+    assert params["width"].group == "Dimensions"
+    assert params["twist"].group == "Style"
+
+
+def test_hidden_group_excluded():
+    src = """
+height = 100;
+/* [Hidden] */
+internal = 5;
+"""
+    params = _by_name(parse_parameters(src))
+    assert "height" in params
+    assert "internal" not in params
+
+
+def test_ignores_non_top_level_variables():
+    src = """
+height = 100;
+module widget() {
+    inner = 5;
+    x = inner * 2;
+}
+function area(r) = 3.14 * r * r;
+"""
+    params = _by_name(parse_parameters(src))
+    assert "height" in params
+    assert "inner" not in params
+    assert "x" not in params
+    assert "area" not in params
+
+
+def test_ignores_includes():
+    src = "include <lib.scad>\nuse <other.scad>\nheight = 10;"
+    params = _by_name(parse_parameters(src))
+    assert list(params.keys()) == ["height"]
+
+
+def test_block_comment_braces_ignored():
+    src = """
+/* a comment with { braces } that should not change depth */
+height = 100;
+"""
+    params = _by_name(parse_parameters(src))
+    assert "height" in params
+    assert params["height"].group is None


### PR DESCRIPTION
## Summary

Adds a new **Generator** module that turns parametric OpenSCAD scripts into printable models: render to STL with PNG previews and an interactive three.js viewer, then save straight into the Library for slicing and printing — `generate → library → slice → print`.

Two ways to use it:
1. **Bundled generators** — curated templates (vase, box) with auto-generated forms.
2. **Upload any `.scad` file** — parameters are auto-discovered and rendered.

OpenSCAD is an **optional, auto-detected dependency**: the nav entry and feature hide themselves when the binary is absent, and the rest of the app is unaffected.

## Backend
- `OpenSCADService` — CLI wrapper; headless STL renders, PNG via `xvfb-run` auto-detection; runs in executor with timeout + output-size cap. Raises `OpenSCADNotAvailableError` / `OpenSCADRenderError`.
- `scad_parser` — discovers parameters from OpenSCAD Customizer comments (ranges, step-ranges, dropdowns, labeled dropdowns, booleans, `/* [Group] */`, `[Hidden]`); top-level assignments only.
- `GeneratorService` — bundled template registry, `.scad` uploads, render jobs (emits `openscad.generation.*` over the existing WebSocket), save-to-Library hand-off, parameter presets.
- `/api/v1/generator` router (trailing-slash policy respected), Pydantic models, `OpenSCADRepository` + migration `032`.
- New config: `OPENSCAD_BINARY_PATH`, `OPENSCAD_RENDER_TIMEOUT`, `OPENSCAD_MAX_OUTPUT_MB`, `GENERATOR_OUTPUT_DIR`.

## Frontend
- Conditional **Generator** page: template gallery, dynamic parameter form (sliders/dropdowns/toggles), `.scad` upload, PNG preview + interactive three.js STL viewer (PNG fallback), save-to-Library, preset save/load.
- three.js loaded via CDN (matching the existing chart.js pattern); de/en i18n keys added.

## Tests & docs
- `tests/test_scad_parser.py` (13) and `tests/test_generator_service.py` (6, OpenSCAD mocked) — all passing; full suite (1572 tests) still collects with no import regressions.
- `docs/openscad-generator.md`, README feature entry, CHANGELOG.

## Verified end-to-end
With OpenSCAD 2021.01 installed in a sandbox: `GET /status` reports available; STL render served (1.26 MB); **save-to-Library** adds the file with checksum; PNG preview rendered via xvfb; `.scad` upload auto-discovers params and renders; presets CRUD all return 200. Removing the binary cleanly degrades to 503 / hidden nav.

## Notes
- Bundled with two generators (vase, box) to exercise sliders, dropdowns and toggles.
- Best-effort sandboxing for uploaded `.scad` (timeout, output cap, isolated working dir); documented in the docs page.
- Version bumped to `2.32.0`.

https://claude.ai/code/session_01YCmpcK1bmUKWrug45RPFKF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCmpcK1bmUKWrug45RPFKF)_