### PR TITLE
chore: Bump version to 2.32.3 (maintenance release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.3] - 2026-06-15
+
+### Changed
+- Maintenance release. Version bump to re-trigger the Home Assistant add-on sync and rebuild, picking up the add-on Dockerfile change that installs `matplotlib` via Alpine's `py3-matplotlib` package — restoring STL/3MF preview thumbnail rendering on the add-on while keeping the core install free of source-built dependencies.
+
 ## [2.32.2] - 2026-06-15
 
 ### Fixed

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.32.2")
+APP_VERSION = get_version(fallback="2.32.3")
 
 
 # Prometheus metrics - initialized once


### PR DESCRIPTION
## Summary

Maintenance patch release `2.32.2` → `2.32.3`.

Bumping the version re-triggers the `sync-to-ha-repo` workflow and the Home Assistant add-on rebuild, so the add-on picks up the `py3-matplotlib` Dockerfile change in `printernizer-ha` — restoring STL/3MF preview thumbnail rendering while keeping the core install free of source-built dependencies.

## Changes
- `src/main.py` — fallback version → `2.32.3`
- `CHANGELOG.md` — `[2.32.3]` maintenance entry

No functional code changes.

https://claude.ai/code/session_01YCmpcK1bmUKWrug45RPFKF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCmpcK1bmUKWrug45RPFKF)_