### PR TITLE
fix: Add generator to nav-preferences defaultSections so it appears in navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.1] - 2026-06-20
+
+### Fixed
+- Generator section missing from navbar after page load. `updateNavigation()` rebuilt the nav entirely from `navigationPreferences.getVisibleSections()`, but `generator` was absent from `defaultSections`, so the nav link was silently dropped on every startup.
+
 ## [2.34.0] - 2026-06-19
 
 ### Changed

--- a/frontend/js/generator.js
+++ b/frontend/js/generator.js
@@ -134,8 +134,7 @@ class GeneratorManager {
     async checkStatus() { this._revealNav(); }
 
     _revealNav() {
-        const navLink = document.getElementById('nav-generator-link');
-        if (navLink) navLink.style.display = '';
+        // Nav link is managed by navigation-preferences; only toggle page-level divs.
         const layout = document.getElementById('generatorLayout');
         if (layout) layout.style.display = '';
         const unavailable = document.getElementById('generatorUnavailable');

--- a/frontend/js/navigation-preferences.js
+++ b/frontend/js/navigation-preferences.js
@@ -84,6 +84,14 @@ class NavigationPreferences {
                 required: false
             },
             {
+                id: 'generator',
+                icon: '🧩',
+                labelKey: 'nav.generator',
+                descriptionKey: 'navDescriptions.generator',
+                visible: true,
+                required: false
+            },
+            {
                 id: 'settings',
                 icon: '⚙️',
                 labelKey: 'nav.settings',

--- a/frontend/locales/de.json
+++ b/frontend/locales/de.json
@@ -1474,6 +1474,7 @@
     "materials": "Filament-Verwaltung und Bestandsübersicht",
     "ideas": "Ideenverwaltung, Lesezeichen und Modell-Entdeckung",
     "tools": "Externe Tools und Helfer für den 3D-Druck",
+    "generator": "Parametrische Modelle im Browser erzeugen",
     "settings": "Anwendungseinstellungen und Konfiguration",
     "debug": "Debug-Informationen und Systemprotokolle",
     "timelines": "Verlauf Ihrer Druckhistorie"

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1474,6 +1474,7 @@
     "materials": "Filament management and inventory overview",
     "ideas": "Idea management, bookmarks and model discovery",
     "tools": "External tools and helpers for 3D printing",
+    "generator": "Generate parametric models in your browser",
     "settings": "Application settings and configuration",
     "debug": "Debug information and system logs",
     "timelines": "Timeline of your print history"

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.34.0")
+APP_VERSION = get_version(fallback="2.34.1")
 
 
 # Prometheus metrics - initialized once


### PR DESCRIPTION
When app.init() calls updateNavigation(), the nav is rebuilt entirely from
navigationPreferences.getVisibleSections(). Because 'generator' was absent
from defaultSections, the static #nav-generator-link element was cleared out
and _revealNav() in generator.js found nothing to show. Fix by adding generator
to defaultSections and removing the stale getElementById lookup (nav is now
always rendered by the preferences system).