### PR TITLE
test: Fix stale generator service test (build123d removal)

### DIFF
--- a/tests/test_generator_service.py
+++ b/tests/test_generator_service.py
@@ -1,4 +1,9 @@
-"""Tests for the build123d GeneratorService (engine mocked)."""
+"""Tests for the browser-side GeneratorService (presets + STL library hand-off).
+
+Geometry is generated client-side (JSCAD), so the server no longer runs a CAD
+engine. The service only reports status, persists named parameter presets, and
+saves a finished STL into the Library.
+"""
 import pathlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -7,7 +12,6 @@ import aiosqlite
 import pytest
 
 from src.services.generator_service import GeneratorService
-from src.services.build123d_service import Build123dService
 
 MIGRATION = pathlib.Path("migrations/033_add_generator_tables.sql").read_text()
 
@@ -24,83 +28,69 @@ async def service(tmp_path, monkeypatch):
     database = SimpleNamespace(_connection=conn)
 
     event_service = SimpleNamespace(emit_event=AsyncMock())
-
-    # Engine with build123d forced "available"; the actual build/export is
-    # stubbed to write a fake STL so the tests don't require build123d/OCP.
-    engine = Build123dService()
-    engine._available = True
-
-    async def fake_render_stl(build_fn, params, stl_path):
-        stl_path.write_bytes(b"solid model\nendsolid model\n")
-
-    engine.render_stl = fake_render_stl
-    engine.render_preview = AsyncMock(return_value=False)
-
     library_service = SimpleNamespace(
         add_file_to_library=AsyncMock(return_value={"id": "lib_1", "status": "ready"})
     )
 
-    svc = GeneratorService(database, event_service, engine, library_service=library_service)
-    # Avoid importing the real (build123d-dependent) template modules.
-    svc._resolve_build_fn = lambda template_id: (lambda **kwargs: object())
+    svc = GeneratorService(database, event_service, library_service=library_service)
     await svc.initialize()
     yield svc
     await conn.close()
     config_module.reload_settings()
 
 
-async def test_bundled_templates_loaded(service):
-    ids = {t.id for t in service.list_templates()}
-    assert "vase" in ids
-    assert "box" in ids
-    box = service.get_template("box")
-    assert any(p.name == "width" for p in box.parameters)
+async def test_status_reports_browser_engine(service):
+    status = service.get_status()
+    assert status.available is True
+    assert status.engine == "jscad"
 
 
-async def test_template_not_found(service):
-    from src.utils.errors import GeneratorTemplateNotFoundError
-    with pytest.raises(GeneratorTemplateNotFoundError):
-        service.get_template("does_not_exist")
-
-
-async def test_param_coercion_clamps_and_types(service):
-    box = service.get_template("box")
-    clean = service._coerce_params(box, {
-        "width": 9999,          # above max -> clamped to 300
-        "wall_thickness": "0",  # below min -> clamped to 1
-        "closed_bottom": "false",
-        "unknown": 5,           # ignored
-    })
-    assert clean["width"] == 300
-    assert clean["wall_thickness"] == 1
-    assert clean["closed_bottom"] is False
-    assert "unknown" not in clean
-
-
-async def test_render_and_save_to_library(service):
-    result = await service.render("box", {"width": 50}, fmt="stl")
-    assert result.status == "completed"
-    assert result.model_url.endswith("/model.stl")
-
-    path = await service.get_artifact_path(result.render_id, "model")
-    assert path is not None and path.exists()
-
-    saved = await service.save_to_library(result.render_id, display_name="My Box")
+async def test_save_stl_to_library(service):
+    saved = await service.save_stl_to_library(
+        stl_bytes=b"solid model\nendsolid model\n",
+        template_id="box",
+        parameters={"width": 50},
+        display_name="My Box",
+    )
     assert saved["id"] == "lib_1"
+
     service.library_service.add_file_to_library.assert_awaited_once()
-    assert service.event_service.emit_event.await_count >= 2
+    call = service.library_service.add_file_to_library.await_args
+    # The staged file is server-named and carries the JSCAD source info.
+    source_info = call.kwargs["source_info"]
+    assert source_info["generator"] == "jscad"
+    assert source_info["template_id"] == "box"
+    assert source_info["parameters"] == {"width": 50}
+    assert source_info["display_name"] == "My_Box.stl"
+
+    # Staged temp file is cleaned up after hand-off.
+    assert list(service.staging_dir.glob("*.stl")) == []
+    service.event_service.emit_event.assert_awaited_once()
 
 
-async def test_unsafe_render_id_rejected(service):
-    assert await service.get_artifact_path("../../etc/passwd", "model") is None
-    from src.utils.errors import GeneratorTemplateNotFoundError
-    with pytest.raises(GeneratorTemplateNotFoundError):
-        await service.save_to_library("../../etc/passwd")
+async def test_save_stl_without_library_service_raises(service):
+    from src.utils.errors import GeneratorError
+    service.library_service = None
+    with pytest.raises(GeneratorError):
+        await service.save_stl_to_library(b"solid\n", "box", {})
 
 
 async def test_presets_roundtrip(service):
     preset = await service.save_preset("box", "Tall", {"height": 250})
+    assert preset.template_id == "box"
+    assert preset.parameters == {"height": 250}
+
     presets = await service.list_presets("box")
     assert any(p.id == preset.id and p.name == "Tall" for p in presets)
+
     await service.delete_preset(preset.id)
     assert await service.list_presets("box") == []
+
+
+async def test_list_presets_filters_by_template(service):
+    await service.save_preset("box", "B1", {"width": 10})
+    await service.save_preset("vase", "V1", {"height": 100})
+
+    box_presets = await service.list_presets("box")
+    assert {p.name for p in box_presets} == {"B1"}
+    assert len(await service.list_presets()) == 2


### PR DESCRIPTION
## Problem

The **CI/CD Pipeline** has failed on every `master` push since v2.34.0. The failure is in the **Backend Tests (Core Tests)** job:

```
ERROR collecting tests/test_generator_service.py
ModuleNotFoundError: No module named 'src.services.build123d_service'
```

When the model generator moved to the browser (JSCAD) in v2.34.0, the server-side `build123d_service.py` and all OpenCascade dependencies were removed — but `tests/test_generator_service.py` was left behind still importing `Build123dService`. pytest collection exits with code 2, which fails the "Check test pass rate" step (all other backend jobs pass).

## Fix

Rewrite `tests/test_generator_service.py` against the current minimal, browser-side `GeneratorService`:

- `get_status()` reports the JSCAD engine
- `save_stl_to_library()` hand-off (source info, staged-file cleanup, event emission, missing-library-service error)
- preset CRUD + template filtering

No CAD engine or `build123d` import remains.

## Verification

All 5 tests pass locally:

```
tests/test_generator_service.py::test_status_reports_browser_engine PASSED
tests/test_generator_service.py::test_save_stl_to_library PASSED
tests/test_generator_service.py::test_save_stl_without_library_service_raises PASSED
tests/test_generator_service.py::test_presets_roundtrip PASSED
tests/test_generator_service.py::test_list_presets_filters_by_template PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)