### PR TITLE
feat: add Printernizer React design system + claude.ai/design sync

### DIFF
--- a/docs/superpowers/plans/2026-06-25-printernizer-design-system.md
+++ b/docs/superpowers/plans/2026-06-25-printernizer-design-system.md
@@ -1,0 +1,2055 @@
+# Printernizer Design System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a React component library at `frontend/react-ds/` that wraps Printernizer's existing CSS class names, builds to ESM + CSS via esbuild, and is ready for `/design-sync` to upload to claude.ai/design.
+
+**Architecture:** 28 TypeScript React components split into `src/core/` (generic) and `src/domain/` (Printernizer-specific), all using existing CSS class names from `frontend/css/`. A single `PrinternizerProvider` sets the active theme. `styles/entry.css` imports the existing stylesheets; esbuild compiles JS + CSS to `dist/`.
+
+**Tech Stack:** TypeScript 5.x, React 18, esbuild 0.25.x, Node 24.x, npm.
+
+## Global Constraints
+
+- All files live under `frontend/react-ds/` — never modify anything outside this directory
+- Components apply CSS classes from existing stylesheets only — no new CSS in component files
+- Global bundle name for design-sync: `PrinternizerDS`
+- TypeScript `strict: true`, `jsx: "react-jsx"`
+- React and react-dom are `peerDependencies` (externalized from bundle)
+- `dist/` is gitignored via `frontend/react-ds/.gitignore`
+- Commit style: Conventional Commits (`feat:`, `chore:`)
+- CSS entry path: `styles/entry.css` → `@import "../../css/main.css"` etc.
+
+---
+
+### Task 1: Scaffold the package
+
+**Files:**
+- Create: `frontend/react-ds/package.json`
+- Create: `frontend/react-ds/tsconfig.json`
+- Create: `frontend/react-ds/build.mjs`
+- Create: `frontend/react-ds/styles/entry.css`
+- Create: `frontend/react-ds/.gitignore`
+- Create: `frontend/react-ds/src/index.ts` (empty barrel, grows in later tasks)
+
+**Interfaces:**
+- Produces: `npm run build` outputs `dist/index.js` and `dist/styles.css`; `npm run typecheck` passes
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p frontend/react-ds/src/core frontend/react-ds/src/domain frontend/react-ds/styles
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/package.json`**
+
+```json
+{
+  "name": "@printernizer/design-system",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node build.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.5.0"
+  }
+}
+```
+
+- [ ] **Step 3: Write `frontend/react-ds/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 4: Write `frontend/react-ds/build.mjs`**
+
+```js
+import * as esbuild from 'esbuild';
+import { mkdirSync } from 'fs';
+
+mkdirSync('dist', { recursive: true });
+
+// JS bundle
+await esbuild.build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  format: 'esm',
+  outfile: 'dist/index.js',
+  external: ['react', 'react-dom', 'react/jsx-runtime'],
+  minify: false,
+  sourcemap: false,
+  target: ['es2020'],
+});
+
+// CSS bundle
+await esbuild.build({
+  entryPoints: ['styles/entry.css'],
+  bundle: true,
+  outfile: 'dist/styles.css',
+  loader: { '.css': 'css' },
+  minify: false,
+});
+
+console.log('Build complete: dist/index.js + dist/styles.css');
+```
+
+- [ ] **Step 5: Write `frontend/react-ds/styles/entry.css`**
+
+```css
+@import "../../css/main.css";
+@import "../../css/components.css";
+@import "../../css/dark-theme.css";
+@import "../../css/themes/theme-refined.css";
+@import "../../css/themes/theme-industrial.css";
+@import "../../css/themes/theme-soft.css";
+@import "../../css/themes/theme-retro.css";
+@import "../../css/themes/theme-brutalist.css";
+```
+
+- [ ] **Step 6: Write `frontend/react-ds/.gitignore`**
+
+```
+dist/
+node_modules/
+```
+
+- [ ] **Step 7: Write `frontend/react-ds/src/index.ts`** (empty barrel for now)
+
+```ts
+// components exported in later tasks
+export {};
+```
+
+- [ ] **Step 8: Install dependencies**
+
+```bash
+cd frontend/react-ds && npm install
+```
+
+Expected: `node_modules/` created, no errors.
+
+- [ ] **Step 9: Verify the build runs**
+
+```bash
+cd frontend/react-ds && npm run build
+```
+
+Expected output:
+```
+Build complete: dist/index.js + dist/styles.css
+```
+Both files must exist. `dist/styles.css` should be non-empty (it bundles all Printernizer CSS).
+
+- [ ] **Step 10: Verify typecheck passes**
+
+```bash
+cd frontend/react-ds && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add frontend/react-ds/
+git commit -m "feat: scaffold Printernizer React design system package"
+```
+
+---
+
+### Task 2: PrinternizerProvider
+
+**Files:**
+- Create: `frontend/react-ds/src/PrinternizerProvider/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- Produces: `PrinternizerProvider`, `PrinternizerTheme` exported from package root
+
+- [ ] **Step 1: Write `frontend/react-ds/src/PrinternizerProvider/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type PrinternizerTheme =
+  | 'default'
+  | 'refined'
+  | 'industrial'
+  | 'soft'
+  | 'retro'
+  | 'brutalist';
+
+export interface PrinternizerProviderProps {
+  theme?: PrinternizerTheme;
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function PrinternizerProvider({
+  theme = 'default',
+  children,
+  className,
+  style,
+}: PrinternizerProviderProps) {
+  return (
+    <div
+      data-theme={theme === 'default' ? undefined : theme}
+      className={className}
+      style={{ minHeight: '100%', ...style }}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update `frontend/react-ds/src/index.ts`**
+
+```ts
+export { PrinternizerProvider } from './PrinternizerProvider';
+export type { PrinternizerProviderProps, PrinternizerTheme } from './PrinternizerProvider';
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+```bash
+cd frontend/react-ds && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add PrinternizerProvider theme wrapper"
+```
+
+---
+
+### Task 3: Button and Card
+
+**Files:**
+- Create: `frontend/react-ds/src/core/Button/index.tsx`
+- Create: `frontend/react-ds/src/core/Card/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- Produces: `Button`, `ButtonProps`, `Card`, `CardProps` exported from package root
+- CSS classes used: `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-success`, `.btn-warning`, `.btn-error`, `.btn-sm`, `.btn-lg`, `.btn-icon`, `.card`, `.card-header`, `.card-body`, `.card-icon`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/core/Button/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'success' | 'warning' | 'error';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  icon?: React.ReactNode;
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+export function Button({
+  variant = 'primary',
+  size,
+  icon,
+  loading = false,
+  children,
+  className,
+  disabled,
+  ...rest
+}: ButtonProps) {
+  const classes = [
+    'btn',
+    `btn-${variant}`,
+    size === 'sm' ? 'btn-sm' : size === 'lg' ? 'btn-lg' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button className={classes} disabled={disabled || loading} {...rest}>
+      {icon && <span className="btn-icon">{icon}</span>}
+      {loading ? '...' : children}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/core/Card/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface CardProps {
+  header?: React.ReactNode;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  hoverable?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function Card({ header, icon, children, hoverable = false, className, style }: CardProps) {
+  return (
+    <div className={['card', hoverable ? 'hoverable' : '', className ?? ''].filter(Boolean).join(' ')} style={style}>
+      {(header || icon) && (
+        <div className="card-header">
+          {icon && <span className="card-icon">{icon}</span>}
+          {header && <h3>{header}</h3>}
+        </div>
+      )}
+      <div className="card-body">{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Update `frontend/react-ds/src/index.ts`**
+
+```ts
+export { PrinternizerProvider } from './PrinternizerProvider';
+export type { PrinternizerProviderProps, PrinternizerTheme } from './PrinternizerProvider';
+
+export { Button } from './core/Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './core/Button';
+
+export { Card } from './core/Card';
+export type { CardProps } from './core/Card';
+```
+
+- [ ] **Step 4: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors; `dist/index.js` updated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add Button and Card core components"
+```
+
+---
+
+### Task 4: Badge, Alert, Toast, Breadcrumb, EmptyState, StatCard
+
+**Files:**
+- Create: `frontend/react-ds/src/core/Badge/index.tsx`
+- Create: `frontend/react-ds/src/core/Alert/index.tsx`
+- Create: `frontend/react-ds/src/core/Toast/index.tsx`
+- Create: `frontend/react-ds/src/core/Breadcrumb/index.tsx`
+- Create: `frontend/react-ds/src/core/EmptyState/index.tsx`
+- Create: `frontend/react-ds/src/core/StatCard/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.status-badge`, `.status-online`, `.status-offline`, `.status-printing`, `.status-idle`, `.status-error`, `.status-completed`, `.alert`, `.alert-success`, `.alert-warning`, `.alert-error`, `.alert-info`, `.toast`, `.toast-header`, `.toast-title`, `.toast-close`, `.toast-body`, `.toast-success`, `.toast-warning`, `.toast-error`, `.toast-info`, `.breadcrumb-back`, `.breadcrumb-separator`, `.empty-state`, `.stat-card`, `.stat-value`, `.stat-label`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/core/Badge/index.tsx`**
+
+Note: The existing CSS uses `.status-badge` + `.status-{variant}` for all semantic pill badges. `Badge` maps to those classes.
+
+```tsx
+import React from 'react';
+
+export type BadgeVariant = 'success' | 'error' | 'warning' | 'info' | 'gray';
+
+const variantClass: Record<BadgeVariant, string> = {
+  success: 'status-completed',
+  error: 'status-error',
+  warning: 'status-printing',
+  info: 'status-online',
+  gray: 'status-idle',
+};
+
+export interface BadgeProps {
+  variant?: BadgeVariant;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Badge({ variant = 'gray', children, className }: BadgeProps) {
+  return (
+    <span className={['status-badge', variantClass[variant], className ?? ''].filter(Boolean).join(' ')}>
+      {children}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/core/Alert/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
+
+export interface AlertProps {
+  variant?: AlertVariant;
+  title?: string;
+  message: React.ReactNode;
+  dismissible?: boolean;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function Alert({ variant = 'info', title, message, dismissible, onDismiss, className }: AlertProps) {
+  return (
+    <div className={['alert', `alert-${variant}`, className ?? ''].filter(Boolean).join(' ')}>
+      {title && <strong>{title} </strong>}
+      {message}
+      {dismissible && (
+        <button
+          onClick={onDismiss}
+          style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem' }}
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Write `frontend/react-ds/src/core/Toast/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type ToastVariant = 'success' | 'warning' | 'error' | 'info';
+
+export interface ToastProps {
+  variant?: ToastVariant;
+  title?: string;
+  message: React.ReactNode;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function Toast({ variant = 'info', title, message, onDismiss, className }: ToastProps) {
+  return (
+    <div className={['toast', `toast-${variant}`, className ?? ''].filter(Boolean).join(' ')}>
+      <div className="toast-header">
+        {title && <span className="toast-title">{title}</span>}
+        {onDismiss && (
+          <button className="toast-close" onClick={onDismiss} aria-label="Close">
+            ×
+          </button>
+        )}
+      </div>
+      <div className="toast-body">{message}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write `frontend/react-ds/src/core/Breadcrumb/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export function Breadcrumb({ items, className }: BreadcrumbProps) {
+  return (
+    <nav className={['breadcrumb-nav', className ?? ''].filter(Boolean).join(' ')} aria-label="Breadcrumb">
+      {items.map((item, i) => (
+        <React.Fragment key={i}>
+          {i > 0 && <span className="breadcrumb-separator">›</span>}
+          {item.href ? (
+            <a className="breadcrumb-back" href={item.href}>
+              {item.label}
+            </a>
+          ) : (
+            <span>{item.label}</span>
+          )}
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 5: Write `frontend/react-ds/src/core/EmptyState/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  message?: string;
+  action?: EmptyStateAction;
+  className?: string;
+}
+
+export function EmptyState({ icon, title, message, action, className }: EmptyStateProps) {
+  return (
+    <div className={['empty-state', className ?? ''].filter(Boolean).join(' ')}>
+      {icon && <div>{icon}</div>}
+      <h3>{title}</h3>
+      {message && <p>{message}</p>}
+      {action && (
+        <button className="btn btn-primary" onClick={action.onClick}>
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Write `frontend/react-ds/src/core/StatCard/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface StatCardProps {
+  label: string;
+  value: React.ReactNode;
+  delta?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function StatCard({ label, value, delta, icon, className }: StatCardProps) {
+  return (
+    <div className={['stat-card', className ?? ''].filter(Boolean).join(' ')}>
+      {icon && <div className="stat-icon">{icon}</div>}
+      <div className="stat-value">{value}</div>
+      <div className="stat-label">{label}</div>
+      {delta && <div className="stat-delta">{delta}</div>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Update `frontend/react-ds/src/index.ts`**
+
+```ts
+export { PrinternizerProvider } from './PrinternizerProvider';
+export type { PrinternizerProviderProps, PrinternizerTheme } from './PrinternizerProvider';
+
+export { Button } from './core/Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './core/Button';
+
+export { Card } from './core/Card';
+export type { CardProps } from './core/Card';
+
+export { Badge } from './core/Badge';
+export type { BadgeProps, BadgeVariant } from './core/Badge';
+
+export { Alert } from './core/Alert';
+export type { AlertProps, AlertVariant } from './core/Alert';
+
+export { Toast } from './core/Toast';
+export type { ToastProps, ToastVariant } from './core/Toast';
+
+export { Breadcrumb } from './core/Breadcrumb';
+export type { BreadcrumbProps, BreadcrumbItem } from './core/Breadcrumb';
+
+export { EmptyState } from './core/EmptyState';
+export type { EmptyStateProps, EmptyStateAction } from './core/EmptyState';
+
+export { StatCard } from './core/StatCard';
+export type { StatCardProps } from './core/StatCard';
+```
+
+- [ ] **Step 8: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add Badge, Alert, Toast, Breadcrumb, EmptyState, StatCard"
+```
+
+---
+
+### Task 5: FormGroup, Input, Select, SearchBox
+
+**Files:**
+- Create: `frontend/react-ds/src/core/FormGroup/index.tsx`
+- Create: `frontend/react-ds/src/core/Input/index.tsx`
+- Create: `frontend/react-ds/src/core/Select/index.tsx`
+- Create: `frontend/react-ds/src/core/SearchBox/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.form-group`, `.form-control`, `.form-control.error`, `.search-controls`, `.search-input-wrapper`, `.search-input`, `.search-clear-btn`, `.search-icon`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/core/FormGroup/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface FormGroupProps {
+  label?: string;
+  required?: boolean;
+  error?: string;
+  hint?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function FormGroup({ label, required, error, hint, children, className }: FormGroupProps) {
+  return (
+    <div className={['form-group', className ?? ''].filter(Boolean).join(' ')}>
+      {label && (
+        <label>
+          {label}
+          {required && <span style={{ color: 'var(--error-color)' }}> *</span>}
+        </label>
+      )}
+      {children}
+      {hint && !error && <small style={{ color: 'var(--gray-500)', display: 'block', marginTop: '0.25rem' }}>{hint}</small>}
+      {error && <small style={{ color: 'var(--error-color)', display: 'block', marginTop: '0.25rem' }}>{error}</small>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/core/Input/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  hint?: string;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+}
+
+export function Input({ label, error, hint, prefix, suffix, className, required, ...rest }: InputProps) {
+  return (
+    <div className="form-group">
+      {label && (
+        <label>
+          {label}
+          {required && <span style={{ color: 'var(--error-color)' }}> *</span>}
+        </label>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        {prefix && <span>{prefix}</span>}
+        <input
+          className={['form-control', error ? 'error' : '', className ?? ''].filter(Boolean).join(' ')}
+          required={required}
+          {...rest}
+        />
+        {suffix && <span>{suffix}</span>}
+      </div>
+      {hint && !error && <small style={{ color: 'var(--gray-500)', display: 'block', marginTop: '0.25rem' }}>{hint}</small>}
+      {error && <small style={{ color: 'var(--error-color)', display: 'block', marginTop: '0.25rem' }}>{error}</small>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Write `frontend/react-ds/src/core/Select/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  label?: string;
+  options: SelectOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  error?: string;
+  placeholder?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Select({ label, options, value, onChange, error, placeholder, required, disabled, className }: SelectProps) {
+  return (
+    <div className="form-group">
+      {label && (
+        <label>
+          {label}
+          {required && <span style={{ color: 'var(--error-color)' }}> *</span>}
+        </label>
+      )}
+      <select
+        className={['form-control', error ? 'error' : '', className ?? ''].filter(Boolean).join(' ')}
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+        required={required}
+        disabled={disabled}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error && <small style={{ color: 'var(--error-color)', display: 'block', marginTop: '0.25rem' }}>{error}</small>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write `frontend/react-ds/src/core/SearchBox/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface SearchBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear?: () => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export function SearchBox({ value, onChange, onClear, placeholder = 'Search…', className }: SearchBoxProps) {
+  return (
+    <div className={['search-controls', className ?? ''].filter(Boolean).join(' ')}>
+      <div className="search-input-wrapper">
+        <span className="search-icon">🔍</span>
+        <input
+          type="search"
+          className="search-input"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+        />
+        {value && (
+          <button className="search-clear-btn" onClick={() => { onChange(''); onClear?.(); }} aria-label="Clear search">
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Update `frontend/react-ds/src/index.ts`** — append:
+
+```ts
+export { FormGroup } from './core/FormGroup';
+export type { FormGroupProps } from './core/FormGroup';
+
+export { Input } from './core/Input';
+export type { InputProps } from './core/Input';
+
+export { Select } from './core/Select';
+export type { SelectProps, SelectOption } from './core/Select';
+
+export { SearchBox } from './core/SearchBox';
+export type { SearchBoxProps } from './core/SearchBox';
+```
+
+- [ ] **Step 6: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add FormGroup, Input, Select, SearchBox"
+```
+
+---
+
+### Task 6: Modal
+
+**Files:**
+- Create: `frontend/react-ds/src/core/Modal/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.modal`, `.modal.show`, `.modal-content`, `.modal-content.large`, `.modal-header`, `.modal-close`, `.modal-body`, `.modal-footer`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/core/Modal/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type ModalSize = 'sm' | 'md' | 'lg';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: ModalSize;
+  footer?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Modal({ open, onClose, title, size = 'md', footer, children, className }: ModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="modal show" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className={['modal-content', size === 'lg' ? 'large' : '', className ?? ''].filter(Boolean).join(' ')}>
+        {title && (
+          <div className="modal-header">
+            <h3>{title}</h3>
+            <button className="modal-close" onClick={onClose} aria-label="Close">×</button>
+          </div>
+        )}
+        <div className="modal-body">{children}</div>
+        {footer && <div className="modal-footer">{footer}</div>}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { Modal } from './core/Modal';
+export type { ModalProps, ModalSize } from './core/Modal';
+```
+
+- [ ] **Step 3: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add Modal"
+```
+
+---
+
+### Task 7: Table and Pagination
+
+**Files:**
+- Create: `frontend/react-ds/src/core/Table/index.tsx`
+- Create: `frontend/react-ds/src/core/Pagination/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.professional-table`, `.table-container`, `.pagination`, `.pagination-btn`, `.pagination-btn.active`, `.pagination-info`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/core/Table/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface TableColumn<T> {
+  key: keyof T;
+  header: string;
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+  sortable?: boolean;
+}
+
+export interface TableProps<T extends Record<string, unknown>> {
+  columns: TableColumn<T>[];
+  data: T[];
+  loading?: boolean;
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function Table<T extends Record<string, unknown>>({
+  columns,
+  data,
+  loading,
+  emptyMessage = 'No data',
+  className,
+}: TableProps<T>) {
+  return (
+    <div className={['table-container', className ?? ''].filter(Boolean).join(' ')}>
+      <table className="professional-table">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th key={String(col.key)}>{col.header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: 'center', padding: '2rem' }}>
+                Loading…
+              </td>
+            </tr>
+          ) : data.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: 'center', padding: '2rem', color: 'var(--gray-500)' }}>
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            data.map((row, rowIdx) => (
+              <tr key={rowIdx}>
+                {columns.map((col) => (
+                  <td key={String(col.key)}>
+                    {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/core/Pagination/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onChange: (page: number) => void;
+  className?: string;
+}
+
+export function Pagination({ page, totalPages, onChange, className }: PaginationProps) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  return (
+    <div className={['pagination', className ?? ''].filter(Boolean).join(' ')}>
+      <button
+        className="pagination-btn"
+        onClick={() => onChange(page - 1)}
+        disabled={page <= 1}
+      >
+        ‹
+      </button>
+      {pages.map((p) => (
+        <button
+          key={p}
+          className={['pagination-btn', p === page ? 'active' : ''].filter(Boolean).join(' ')}
+          onClick={() => onChange(p)}
+        >
+          {p}
+        </button>
+      ))}
+      <button
+        className="pagination-btn"
+        onClick={() => onChange(page + 1)}
+        disabled={page >= totalPages}
+      >
+        ›
+      </button>
+      <span className="pagination-info">
+        Page {page} of {totalPages}
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { Table } from './core/Table';
+export type { TableProps, TableColumn } from './core/Table';
+
+export { Pagination } from './core/Pagination';
+export type { PaginationProps } from './core/Pagination';
+```
+
+- [ ] **Step 4: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add Table and Pagination"
+```
+
+---
+
+### Task 8: PageHeader and NavSidebar
+
+**Files:**
+- Create: `frontend/react-ds/src/domain/PageHeader/index.tsx`
+- Create: `frontend/react-ds/src/domain/NavSidebar/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.page-header`, `.nav-container`, `.nav-menu`, `.nav-link`, `.nav-link.active`, `.nav-icon`, `.nav-brand`, `.status-dot`, `.status-dot.connected`, `.status-dot.disconnected`, `.status-dot.connecting`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/domain/PageHeader/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  breadcrumb?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function PageHeader({ title, subtitle, breadcrumb, actions, className }: PageHeaderProps) {
+  return (
+    <div className={['page-header', className ?? ''].filter(Boolean).join(' ')}>
+      {breadcrumb && <div className="page-breadcrumb">{breadcrumb}</div>}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <h1>{title}</h1>
+          {subtitle && <p style={{ color: 'var(--gray-500)', marginBottom: 0 }}>{subtitle}</p>}
+        </div>
+        {actions && <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>{actions}</div>}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/domain/NavSidebar/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type ConnectionStatus = 'connected' | 'disconnected' | 'connecting';
+
+export interface NavItem {
+  label: string;
+  icon?: React.ReactNode;
+  href: string;
+  active?: boolean;
+}
+
+export interface NavSidebarProps {
+  items: NavItem[];
+  connectionStatus?: ConnectionStatus;
+  appVersion?: string;
+  className?: string;
+}
+
+export function NavSidebar({ items, connectionStatus, appVersion, className }: NavSidebarProps) {
+  return (
+    <nav className={['nav-container', className ?? ''].filter(Boolean).join(' ')}>
+      <div className="nav-brand">Printernizer</div>
+      <ul className="nav-menu" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {items.map((item) => (
+          <li key={item.href}>
+            <a
+              href={item.href}
+              className={['nav-link', item.active ? 'active' : ''].filter(Boolean).join(' ')}
+            >
+              {item.icon && <span className="nav-icon">{item.icon}</span>}
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+      {connectionStatus && (
+        <div className="nav-status" style={{ padding: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span className={`status-dot ${connectionStatus}`} />
+          <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--gray-500)' }}>
+            {connectionStatus === 'connected' ? 'Connected' : connectionStatus === 'connecting' ? 'Connecting…' : 'Disconnected'}
+          </span>
+        </div>
+      )}
+      {appVersion && (
+        <div style={{ padding: '0 1rem 1rem', fontSize: 'var(--font-size-xs)', color: 'var(--gray-400)' }}>
+          v{appVersion}
+        </div>
+      )}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 3: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { PageHeader } from './domain/PageHeader';
+export type { PageHeaderProps } from './domain/PageHeader';
+
+export { NavSidebar } from './domain/NavSidebar';
+export type { NavSidebarProps, NavItem, ConnectionStatus } from './domain/NavSidebar';
+```
+
+- [ ] **Step 4: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add PageHeader and NavSidebar domain components"
+```
+
+---
+
+### Task 9: PrinterStatusBadge, StatusBadge, PrinterTypeIcon
+
+**Files:**
+- Create: `frontend/react-ds/src/domain/PrinterStatusBadge/index.tsx`
+- Create: `frontend/react-ds/src/domain/StatusBadge/index.tsx`
+- Create: `frontend/react-ds/src/domain/PrinterTypeIcon/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.status-dot`, `.status-dot.connected`, `.status-dot.disconnected`, `.status-dot.connecting`, `.status-badge`, `.status-idle`, `.status-printing`, `.status-error`, `.status-completed`, `.status-offline`, `.status-planned`, `.status-idea`, `.status-archived`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/domain/PrinterStatusBadge/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type PrinterStatus = 'idle' | 'printing' | 'error' | 'offline' | 'connecting';
+
+export interface PrinterStatusBadgeProps {
+  status: PrinterStatus;
+  showLabel?: boolean;
+  className?: string;
+}
+
+const dotClass: Record<PrinterStatus, string> = {
+  idle: 'connected',
+  printing: 'connected',
+  error: 'disconnected',
+  offline: 'disconnected',
+  connecting: 'connecting',
+};
+
+const labels: Record<PrinterStatus, string> = {
+  idle: 'Idle',
+  printing: 'Printing',
+  error: 'Error',
+  offline: 'Offline',
+  connecting: 'Connecting',
+};
+
+export function PrinterStatusBadge({ status, showLabel = true, className }: PrinterStatusBadgeProps) {
+  return (
+    <span
+      className={['status-badge', `status-${status}`, className ?? ''].filter(Boolean).join(' ')}
+    >
+      <span className={`status-dot ${dotClass[status]}`} />
+      {showLabel && labels[status]}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/domain/StatusBadge/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type IdeaStatus = 'idea' | 'planned' | 'printing' | 'completed' | 'archived';
+
+export interface StatusBadgeProps {
+  status: IdeaStatus;
+  label?: string;
+  className?: string;
+}
+
+export function StatusBadge({ status, label, className }: StatusBadgeProps) {
+  const displayLabel = label ?? status.charAt(0).toUpperCase() + status.slice(1);
+  return (
+    <span className={['status-badge', `status-${status}`, className ?? ''].filter(Boolean).join(' ')}>
+      {displayLabel}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Write `frontend/react-ds/src/domain/PrinterTypeIcon/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type PrinterType = 'bambu' | 'prusa';
+export type IconSize = 'sm' | 'md' | 'lg';
+
+export interface PrinterTypeIconProps {
+  type: PrinterType;
+  size?: IconSize;
+  className?: string;
+}
+
+const sizePx: Record<IconSize, number> = { sm: 16, md: 24, lg: 32 };
+
+export function PrinterTypeIcon({ type, size = 'md', className }: PrinterTypeIconProps) {
+  const px = sizePx[size];
+
+  if (type === 'bambu') {
+    return (
+      <svg
+        width={px}
+        height={px}
+        viewBox="0 0 24 24"
+        fill="none"
+        className={className}
+        aria-label="Bambu Lab"
+      >
+        <rect width="24" height="24" rx="4" fill="#F97316" />
+        <text x="12" y="17" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold">B</text>
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width={px}
+      height={px}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-label="Prusa"
+    >
+      <rect width="24" height="24" rx="4" fill="#DC2626" />
+      <text x="12" y="17" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold">P</text>
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 4: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { PrinterStatusBadge } from './domain/PrinterStatusBadge';
+export type { PrinterStatusBadgeProps, PrinterStatus } from './domain/PrinterStatusBadge';
+
+export { StatusBadge } from './domain/StatusBadge';
+export type { StatusBadgeProps, IdeaStatus } from './domain/StatusBadge';
+
+export { PrinterTypeIcon } from './domain/PrinterTypeIcon';
+export type { PrinterTypeIconProps, PrinterType, IconSize } from './domain/PrinterTypeIcon';
+```
+
+- [ ] **Step 5: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add PrinterStatusBadge, StatusBadge, PrinterTypeIcon"
+```
+
+---
+
+### Task 10: PrintProgressBar and PrinterCard
+
+**Files:**
+- Create: `frontend/react-ds/src/domain/PrintProgressBar/index.tsx`
+- Create: `frontend/react-ds/src/domain/PrinterCard/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- Consumes: `PrinterStatusBadge`, `PrinterStatus` from Task 9; `PrinterTypeIcon`, `PrinterType` from Task 9
+- CSS classes used: `.progress`, `.progress-bar`, `.progress-success`, `.progress-warning`, `.progress-error`, `.progress-animated`, `.progress-header`, `.progress-label`, `.progress-details`, `.printer-card`, `.card`, `.card-header`, `.card-body`, `.connection-indicator`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/domain/PrintProgressBar/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type ProgressStatus = 'printing' | 'success' | 'error' | 'warning';
+
+export interface PrintProgressBarProps {
+  progress: number;
+  status?: ProgressStatus;
+  timeRemaining?: string;
+  label?: string;
+  className?: string;
+}
+
+const statusClass: Record<ProgressStatus, string> = {
+  printing: 'progress-animated',
+  success: 'progress-success',
+  error: 'progress-error',
+  warning: 'progress-warning',
+};
+
+export function PrintProgressBar({ progress, status = 'printing', timeRemaining, label, className }: PrintProgressBarProps) {
+  const clamped = Math.max(0, Math.min(100, progress));
+  return (
+    <div className={['progress-wrapper', statusClass[status], className ?? ''].filter(Boolean).join(' ')}>
+      {(label || timeRemaining) && (
+        <div className="progress-header">
+          {label && <span className="progress-label">{label}</span>}
+          {timeRemaining && <span className="progress-details">{timeRemaining}</span>}
+        </div>
+      )}
+      <div className="progress">
+        <div
+          className="progress-bar"
+          style={{ width: `${clamped}%` }}
+          role="progressbar"
+          aria-valuenow={clamped}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/domain/PrinterCard/index.tsx`**
+
+```tsx
+import React from 'react';
+import { PrinterStatusBadge } from '../PrinterStatusBadge';
+import type { PrinterStatus } from '../PrinterStatusBadge';
+import { PrinterTypeIcon } from '../PrinterTypeIcon';
+import type { PrinterType } from '../PrinterTypeIcon';
+import { PrintProgressBar } from '../PrintProgressBar';
+
+export interface PrinterData {
+  id: string;
+  name: string;
+  status: PrinterStatus;
+  printerType: PrinterType;
+  cameraUrl?: string;
+  progress?: number;
+  currentFile?: string;
+  timeRemaining?: string;
+}
+
+export interface PrinterCardProps {
+  printer: PrinterData;
+  onAction?: (action: 'pause' | 'resume' | 'cancel' | 'settings', printerId: string) => void;
+  monitoring?: boolean;
+  className?: string;
+}
+
+export function PrinterCard({ printer, onAction, monitoring = false, className }: PrinterCardProps) {
+  return (
+    <div
+      className={[
+        'card',
+        'printer-card',
+        monitoring ? 'monitoring-active' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="card-header">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <PrinterTypeIcon type={printer.printerType} size="md" />
+          <div>
+            <h3 style={{ margin: 0, fontSize: 'var(--font-size-base)', fontWeight: 600 }}>{printer.name}</h3>
+            <PrinterStatusBadge status={printer.status} />
+          </div>
+        </div>
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={() => onAction?.('settings', printer.id)}
+          aria-label="Printer settings"
+        >
+          ⚙
+        </button>
+      </div>
+      <div className="card-body">
+        {printer.cameraUrl ? (
+          <img
+            src={printer.cameraUrl}
+            alt={`${printer.name} camera`}
+            style={{ width: '100%', borderRadius: 'var(--radius-md)', marginBottom: '1rem' }}
+          />
+        ) : (
+          <div className="camera-placeholder">
+            <span className="camera-icon">📷</span>
+            <span className="camera-text">No camera</span>
+          </div>
+        )}
+        {printer.status === 'printing' && printer.progress !== undefined && (
+          <PrintProgressBar
+            progress={printer.progress}
+            status="printing"
+            label={printer.currentFile}
+            timeRemaining={printer.timeRemaining}
+          />
+        )}
+        {printer.status === 'printing' && (
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem' }}>
+            <button className="btn btn-warning btn-sm" onClick={() => onAction?.('pause', printer.id)}>
+              Pause
+            </button>
+            <button className="btn btn-error btn-sm" onClick={() => onAction?.('cancel', printer.id)}>
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { PrintProgressBar } from './domain/PrintProgressBar';
+export type { PrintProgressBarProps, ProgressStatus } from './domain/PrintProgressBar';
+
+export { PrinterCard } from './domain/PrinterCard';
+export type { PrinterCardProps, PrinterData } from './domain/PrinterCard';
+```
+
+- [ ] **Step 4: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add PrintProgressBar and PrinterCard"
+```
+
+---
+
+### Task 11: JobListItem, FileListItem, FileThumbnail
+
+**Files:**
+- Create: `frontend/react-ds/src/domain/JobListItem/index.tsx`
+- Create: `frontend/react-ds/src/domain/FileThumbnail/index.tsx`
+- Create: `frontend/react-ds/src/domain/FileListItem/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- Consumes: `PrinterStatus` from Task 9
+- CSS classes used: `.file-item`, `.file-thumbnail`, `.status-badge`, `.status-printing`, `.status-completed`, `.status-error`, `.status-idle`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/domain/FileThumbnail/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type FileType = 'stl' | '3mf' | 'gcode' | 'image';
+export type ThumbnailSize = 'sm' | 'md' | 'lg';
+
+export interface FileThumbnailProps {
+  src?: string;
+  fileType: FileType;
+  animated?: boolean;
+  size?: ThumbnailSize;
+  alt?: string;
+  className?: string;
+}
+
+const sizePx: Record<ThumbnailSize, number> = { sm: 48, md: 80, lg: 128 };
+const typeEmoji: Record<FileType, string> = { stl: '🧊', '3mf': '🖨', gcode: '📄', image: '🖼' };
+
+export function FileThumbnail({ src, fileType, animated, size = 'md', alt, className }: FileThumbnailProps) {
+  const px = sizePx[size];
+  return (
+    <div
+      className={['file-thumbnail', animated ? 'animated' : '', className ?? ''].filter(Boolean).join(' ')}
+      style={{ width: px, height: px, flexShrink: 0 }}
+    >
+      {src ? (
+        <img src={src} alt={alt ?? fileType} style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: 'var(--radius-md)' }} />
+      ) : (
+        <span style={{ fontSize: px * 0.5, display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+          {typeEmoji[fileType]}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/domain/JobListItem/index.tsx`**
+
+```tsx
+import React from 'react';
+import type { PrinterStatus } from '../PrinterStatusBadge';
+
+export interface JobData {
+  id: string;
+  name: string;
+  printer: string;
+  progress: number;
+  status: PrinterStatus;
+  duration?: string;
+  startedAt?: string;
+}
+
+export interface JobListItemProps {
+  job: JobData;
+  onClick?: (jobId: string) => void;
+  className?: string;
+}
+
+const jobStatusClass: Record<PrinterStatus, string> = {
+  printing: 'status-printing',
+  idle: 'status-idle',
+  error: 'status-error',
+  offline: 'status-offline',
+  connecting: 'status-idle',
+};
+
+export function JobListItem({ job, onClick, className }: JobListItemProps) {
+  return (
+    <div
+      className={['file-item', className ?? ''].filter(Boolean).join(' ')}
+      onClick={() => onClick?.(job.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flex: 1 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontWeight: 600, color: 'var(--gray-900)' }}>{job.name}</div>
+          <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--gray-500)' }}>
+            {job.printer} {job.startedAt && `· ${job.startedAt}`}
+          </div>
+        </div>
+        {job.status === 'printing' && (
+          <div style={{ width: 120 }}>
+            <div className="progress">
+              <div className="progress-bar" style={{ width: `${job.progress}%` }} />
+            </div>
+            <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--gray-500)', marginTop: '0.25rem' }}>
+              {job.progress}%
+            </div>
+          </div>
+        )}
+        <span className={`status-badge ${jobStatusClass[job.status]}`}>
+          {job.status}
+        </span>
+        {job.duration && (
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--gray-500)' }}>{job.duration}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Write `frontend/react-ds/src/domain/FileListItem/index.tsx`**
+
+```tsx
+import React from 'react';
+import { FileThumbnail } from '../FileThumbnail';
+import type { FileType } from '../FileThumbnail';
+
+export interface FileData {
+  id: string;
+  name: string;
+  size: string;
+  type: FileType;
+  thumbnailUrl?: string;
+  uploadedAt?: string;
+}
+
+export interface FileListItemProps {
+  file: FileData;
+  onClick?: (fileId: string) => void;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function FileListItem({ file, onClick, actions, className }: FileListItemProps) {
+  return (
+    <div
+      className={['file-item', className ?? ''].filter(Boolean).join(' ')}
+      onClick={() => onClick?.(file.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <FileThumbnail src={file.thumbnailUrl} fileType={file.type} size="sm" alt={file.name} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600, color: 'var(--gray-900)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {file.name}
+        </div>
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--gray-500)' }}>
+          {file.size} {file.uploadedAt && `· ${file.uploadedAt}`}
+        </div>
+      </div>
+      {actions && <div onClick={(e) => e.stopPropagation()}>{actions}</div>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { FileThumbnail } from './domain/FileThumbnail';
+export type { FileThumbnailProps, FileType, ThumbnailSize } from './domain/FileThumbnail';
+
+export { JobListItem } from './domain/JobListItem';
+export type { JobListItemProps, JobData } from './domain/JobListItem';
+
+export { FileListItem } from './domain/FileListItem';
+export type { FileListItemProps, FileData } from './domain/FileListItem';
+```
+
+- [ ] **Step 5: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add JobListItem, FileListItem, FileThumbnail"
+```
+
+---
+
+### Task 12: CameraView, IdeaCard, MaterialCard
+
+**Files:**
+- Create: `frontend/react-ds/src/domain/CameraView/index.tsx`
+- Create: `frontend/react-ds/src/domain/IdeaCard/index.tsx`
+- Create: `frontend/react-ds/src/domain/MaterialCard/index.tsx`
+- Modify: `frontend/react-ds/src/index.ts`
+
+**Interfaces:**
+- CSS classes used: `.camera-section`, `.camera-stream`, `.camera-placeholder`, `.camera-controls`, `.idea-card`, `.material-card`, `.material-card-header`, `.material-name`, `.material-info`, `.material-progress`, `.material-type-badge`, `.material-status-badge`, `.material-status-badge.low`, `.material-status-badge.out`
+
+- [ ] **Step 1: Write `frontend/react-ds/src/domain/CameraView/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type CameraStatus = 'active' | 'inactive' | 'error';
+
+export interface CameraViewProps {
+  streamUrl?: string;
+  snapshotUrl?: string;
+  status: CameraStatus;
+  printerName?: string;
+  onSnapshot?: () => void;
+  className?: string;
+}
+
+export function CameraView({ streamUrl, snapshotUrl, status, printerName, onSnapshot, className }: CameraViewProps) {
+  return (
+    <div className={['camera-section', className ?? ''].filter(Boolean).join(' ')}>
+      {status === 'active' && streamUrl ? (
+        <div className="camera-preview-container">
+          <img
+            src={streamUrl}
+            alt={printerName ? `${printerName} camera` : 'Camera feed'}
+            className="camera-stream"
+          />
+        </div>
+      ) : (
+        <div className="camera-placeholder">
+          <span className="placeholder-icon">📷</span>
+          <span className="placeholder-text">
+            {status === 'error' ? 'Camera unavailable' : 'No camera feed'}
+          </span>
+          {printerName && <small>{printerName}</small>}
+        </div>
+      )}
+      {onSnapshot && status === 'active' && (
+        <div className="camera-controls">
+          <button className="btn btn-secondary btn-sm" onClick={onSnapshot}>
+            📸 Snapshot
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `frontend/react-ds/src/domain/IdeaCard/index.tsx`**
+
+```tsx
+import React from 'react';
+import { StatusBadge } from '../StatusBadge';
+import type { IdeaStatus } from '../StatusBadge';
+
+export interface IdeaData {
+  id: string;
+  title: string;
+  platform?: string;
+  tags?: string[];
+  thumbnailUrl?: string;
+  bookmarked?: boolean;
+  status?: IdeaStatus;
+}
+
+export interface IdeaCardProps {
+  idea: IdeaData;
+  onClick?: (ideaId: string) => void;
+  onBookmark?: (ideaId: string, bookmarked: boolean) => void;
+  className?: string;
+}
+
+export function IdeaCard({ idea, onClick, onBookmark, className }: IdeaCardProps) {
+  return (
+    <div
+      className={['idea-card', className ?? ''].filter(Boolean).join(' ')}
+      onClick={() => onClick?.(idea.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      {idea.thumbnailUrl && (
+        <img
+          src={idea.thumbnailUrl}
+          alt={idea.title}
+          style={{ width: '100%', aspectRatio: '4/3', objectFit: 'cover' }}
+        />
+      )}
+      <div style={{ padding: '0.75rem' }}>
+        <div style={{ fontWeight: 600, color: 'var(--gray-900)', marginBottom: '0.25rem' }}>{idea.title}</div>
+        {idea.platform && (
+          <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--gray-500)', marginBottom: '0.5rem' }}>
+            {idea.platform}
+          </div>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          {idea.status && <StatusBadge status={idea.status} />}
+          {idea.tags?.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      </div>
+      {onBookmark && (
+        <button
+          className="btn btn-secondary btn-sm"
+          style={{ position: 'absolute', top: '0.5rem', right: '0.5rem' }}
+          onClick={(e) => { e.stopPropagation(); onBookmark(idea.id, !idea.bookmarked); }}
+          aria-label={idea.bookmarked ? 'Remove bookmark' : 'Bookmark'}
+        >
+          {idea.bookmarked ? '★' : '☆'}
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Write `frontend/react-ds/src/domain/MaterialCard/index.tsx`**
+
+```tsx
+import React from 'react';
+
+export type MaterialStockStatus = 'ok' | 'low' | 'out';
+
+export interface MaterialData {
+  id: string;
+  name: string;
+  color: string;
+  type: string;
+  remainingGrams?: number;
+  totalGrams?: number;
+  stockStatus?: MaterialStockStatus;
+}
+
+export interface MaterialCardProps {
+  material: MaterialData;
+  onClick?: (materialId: string) => void;
+  className?: string;
+}
+
+export function MaterialCard({ material, onClick, className }: MaterialCardProps) {
+  const pct =
+    material.remainingGrams !== undefined && material.totalGrams
+      ? Math.round((material.remainingGrams / material.totalGrams) * 100)
+      : undefined;
+
+  return (
+    <div
+      className={[
+        'material-card',
+        material.stockStatus === 'low' ? 'low-stock' : '',
+        material.stockStatus === 'out' ? 'out-of-stock' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={() => onClick?.(material.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <div className="material-card-header">
+        <span
+          className="material-color-indicator"
+          style={{ backgroundColor: material.color, width: 16, height: 16, borderRadius: '50%', display: 'inline-block', marginRight: '0.5rem' }}
+        />
+        <span className="material-name">{material.name}</span>
+        <span className="material-type-badge">{material.type}</span>
+      </div>
+      <div className="material-info">
+        {material.remainingGrams !== undefined && (
+          <div className="material-detail-item">
+            <span className="material-detail-label">Remaining</span>
+            <span className="material-detail-value">{material.remainingGrams}g</span>
+          </div>
+        )}
+        {material.stockStatus && material.stockStatus !== 'ok' && (
+          <span className={['material-status-badge', material.stockStatus].join(' ')}>
+            {material.stockStatus === 'low' ? 'Low stock' : 'Out of stock'}
+          </span>
+        )}
+      </div>
+      {pct !== undefined && (
+        <div className="material-progress">
+          <div className="progress">
+            <div className="progress-bar" style={{ width: `${pct}%` }} />
+          </div>
+          <span className="material-progress-label">{pct}%</span>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Append to `frontend/react-ds/src/index.ts`**
+
+```ts
+export { CameraView } from './domain/CameraView';
+export type { CameraViewProps, CameraStatus } from './domain/CameraView';
+
+export { IdeaCard } from './domain/IdeaCard';
+export type { IdeaCardProps, IdeaData } from './domain/IdeaCard';
+
+export { MaterialCard } from './domain/MaterialCard';
+export type { MaterialCardProps, MaterialData, MaterialStockStatus } from './domain/MaterialCard';
+```
+
+- [ ] **Step 5: Verify typecheck + build**
+
+```bash
+cd frontend/react-ds && npm run typecheck && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/react-ds/src/
+git commit -m "feat: add CameraView, IdeaCard, MaterialCard"
+```
+
+---
+
+### Task 13: Final build verification and design-sync handoff
+
+**Files:**
+- No new files — verifies the complete package is ready for `/design-sync`
+
+**Interfaces:**
+- Produces: clean `npm run build` + `npm run typecheck`; confirmed exports in `dist/index.js`
+
+- [ ] **Step 1: Full typecheck**
+
+```bash
+cd frontend/react-ds && npm run typecheck
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 2: Full build**
+
+```bash
+cd frontend/react-ds && npm run build
+```
+
+Expected:
+```
+Build complete: dist/index.js + dist/styles.css
+```
+
+- [ ] **Step 3: Verify export count**
+
+```bash
+grep -c "^export" frontend/react-ds/dist/index.js || node -e "
+  import('./frontend/react-ds/dist/index.js').then(m => {
+    console.log('Exports:', Object.keys(m).join(', '));
+  });
+"
+```
+
+Alternatively, count the named exports in `src/index.ts`:
+
+```bash
+grep "^export {" frontend/react-ds/src/index.ts | wc -l
+```
+
+Expected: 28 component exports (14 component + 14 type pairs).
+
+- [ ] **Step 4: Verify `dist/styles.css` contains Printernizer tokens**
+
+```bash
+grep "primary-color\|gray-900\|spacing-4" frontend/react-ds/dist/styles.css | head -5
+```
+
+Expected: matches found — confirms the existing CSS was bundled correctly.
+
+- [ ] **Step 5: Confirm `dist/` is not tracked by git**
+
+```bash
+git status frontend/react-ds/dist/
+```
+
+Expected: `dist/` not shown (gitignored).
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add frontend/react-ds/src/index.ts
+git commit -m "feat: complete Printernizer React design system — 28 components ready for design-sync"
+```
+
+- [ ] **Step 7: Run `/design-sync`**
+
+The component library is now ready. From `frontend/react-ds/`, invoke:
+
+```
+/design-sync
+```
+
+The skill will detect `shape: package` (no Storybook), run its converter, generate `.d.ts`-derived usage guides per component, capture preview cards, and upload to a new claude.ai/design project named **"Printernizer Design System"**.
+
+Note: the spec lists `globalName: PrinternizerDS` — this is NOT an esbuild option in ESM format. The design-sync skill's converter creates its own IIFE bundle with that global. When the skill asks for config, confirm `globalName: "PrinternizerDS"` in `.design-sync/config.json`.
+
+---
+
+## File map summary
+
+```
+frontend/react-ds/
+├── package.json                         Task 1
+├── tsconfig.json                        Task 1
+├── build.mjs                            Task 1
+├── .gitignore                           Task 1
+├── styles/entry.css                     Task 1
+└── src/
+    ├── index.ts                         Tasks 1–12 (grows each task)
+    ├── PrinternizerProvider/index.tsx   Task 2
+    ├── core/
+    │   ├── Button/index.tsx             Task 3
+    │   ├── Card/index.tsx               Task 3
+    │   ├── Badge/index.tsx              Task 4
+    │   ├── Alert/index.tsx              Task 4
+    │   ├── Toast/index.tsx              Task 4
+    │   ├── Breadcrumb/index.tsx         Task 4
+    │   ├── EmptyState/index.tsx         Task 4
+    │   ├── StatCard/index.tsx           Task 4
+    │   ├── FormGroup/index.tsx          Task 5
+    │   ├── Input/index.tsx              Task 5
+    │   ├── Select/index.tsx             Task 5
+    │   ├── SearchBox/index.tsx          Task 5
+    │   ├── Modal/index.tsx              Task 6
+    │   ├── Table/index.tsx              Task 7
+    │   └── Pagination/index.tsx         Task 7
+    └── domain/
+        ├── PageHeader/index.tsx         Task 8
+        ├── NavSidebar/index.tsx         Task 8
+        ├── PrinterStatusBadge/index.tsx Task 9
+        ├── StatusBadge/index.tsx        Task 9
+        ├── PrinterTypeIcon/index.tsx    Task 9
+        ├── PrintProgressBar/index.tsx   Task 10
+        ├── PrinterCard/index.tsx        Task 10
+        ├── FileThumbnail/index.tsx      Task 11
+        ├── JobListItem/index.tsx        Task 11
+        ├── FileListItem/index.tsx       Task 11
+        ├── CameraView/index.tsx         Task 12
+        ├── IdeaCard/index.tsx           Task 12
+        └── MaterialCard/index.tsx       Task 12
+```

--- a/docs/superpowers/specs/2026-06-24-printernizer-design-system-design.md
+++ b/docs/superpowers/specs/2026-06-24-printernizer-design-system-design.md
@@ -1,0 +1,177 @@
+# Printernizer React Design System
+
+**Date:** 2026-06-24  
+**Goal:** Create a React component library from the existing Printernizer vanilla JS/CSS frontend and sync it to claude.ai/design, so the design agent can produce new Printernizer screens using the real visual language.
+
+---
+
+## 1. Approach
+
+CSS-wrapper React library. React components apply the exact CSS class names already present in the Printernizer stylesheets. No re-styling. The bundle ships the existing CSS files unchanged. Output is consumed by the `/design-sync` skill to upload to a claude.ai/design project.
+
+---
+
+## 2. Repository location
+
+New package at `printernizer/frontend/react-ds/` — co-located with the existing frontend so it can import CSS files via relative paths.
+
+```
+frontend/react-ds/
+├── package.json
+├── tsconfig.json
+├── build.mjs                 # esbuild script
+├── src/
+│   ├── index.ts              # barrel export
+│   ├── core/                 # generic reusable components
+│   │   ├── Button/index.tsx
+│   │   ├── Card/index.tsx
+│   │   ├── Modal/index.tsx
+│   │   ├── Alert/index.tsx
+│   │   ├── Badge/index.tsx
+│   │   ├── Toast/index.tsx
+│   │   ├── Input/index.tsx
+│   │   ├── Select/index.tsx
+│   │   ├── Table/index.tsx
+│   │   ├── Pagination/index.tsx
+│   │   ├── SearchBox/index.tsx
+│   │   ├── StatCard/index.tsx
+│   │   ├── Breadcrumb/index.tsx
+│   │   ├── EmptyState/index.tsx
+│   │   └── FormGroup/index.tsx
+│   ├── domain/               # Printernizer-specific components
+│   │   ├── PrinterCard/index.tsx
+│   │   ├── PrinterStatusBadge/index.tsx
+│   │   ├── JobListItem/index.tsx
+│   │   ├── PrintProgressBar/index.tsx
+│   │   ├── FileListItem/index.tsx
+│   │   ├── FileThumbnail/index.tsx
+│   │   ├── CameraView/index.tsx
+│   │   ├── StatusBadge/index.tsx
+│   │   ├── IdeaCard/index.tsx
+│   │   ├── MaterialCard/index.tsx
+│   │   ├── PageHeader/index.tsx
+│   │   ├── PrinterTypeIcon/index.tsx
+│   │   └── NavSidebar/index.tsx
+│   └── PrinternizerProvider/
+│       └── index.tsx         # theme wrapper, sets data-theme on root div
+├── styles/
+│   └── entry.css             # @imports all existing CSS files
+└── dist/                     # build output (gitignored)
+    ├── index.js
+    └── styles.css
+```
+
+---
+
+## 3. Component inventory
+
+### Core components (15)
+
+| Component | Key props | CSS classes |
+|---|---|---|
+| `Button` | `variant` (primary/secondary/success/warning/error/ghost), `size` (sm/md/lg), `icon`, `loading`, `disabled` | `.btn .btn-{variant} .btn-{size}` |
+| `Card` | `header`, `icon`, `children`, `hoverable` | `.card .card-header .card-body` |
+| `Badge` | `variant` (success/warning/error/info/gray), `size` | `.badge .badge-{variant}` |
+| `Alert` | `variant`, `title`, `message`, `dismissible`, `onDismiss` | `.alert .alert-{variant}` |
+| `Modal` | `open`, `onClose`, `title`, `size` (sm/md/lg), `footer` | `.modal .modal-content .modal-header .modal-body .modal-footer` |
+| `Toast` | `variant`, `message`, `duration`, `onDismiss` | `.toast .toast-{variant}` |
+| `Input` | `label`, `error`, `hint`, `prefix`, `suffix`, `type` | `.form-group .form-control` |
+| `Select` | `label`, `options`, `error`, `value`, `onChange` | `.form-group select` |
+| `Table` | `columns`, `data`, `sortable`, `loading`, `emptyMessage` | `.table` |
+| `Pagination` | `page`, `totalPages`, `onChange` | `.pagination` |
+| `SearchBox` | `value`, `onChange`, `placeholder`, `onClear` | `.search-box` |
+| `StatCard` | `label`, `value`, `delta`, `icon`, `variant` | `.stat-card` |
+| `Breadcrumb` | `items` (`{label: string, href?: string}[]`) | `.breadcrumb` |
+| `EmptyState` | `icon`, `title`, `message`, `action` | `.empty-state` |
+| `FormGroup` | `label`, `required`, `error`, `hint`, `children` | `.form-group` |
+
+### Domain components (13)
+
+| Component | Key props | CSS classes |
+|---|---|---|
+| `PrinterCard` | `printer` (id, name, status, printerType, cameraUrl), `onAction` | `.printer-card .status-{status}` |
+| `PrinterStatusBadge` | `status` (idle/printing/error/offline/connecting) | `.status-dot .status-{status}` |
+| `JobListItem` | `job` (id, name, printer, progress, status, duration, startedAt) | `.job-list-item` |
+| `PrintProgressBar` | `progress` (0–100), `status`, `timeRemaining` | `.progress-bar` |
+| `FileListItem` | `file` (id, name, size, type, thumbnailUrl, uploadedAt) | `.file-item` |
+| `FileThumbnail` | `src`, `fileType` (stl/3mf/gcode/image), `animated`, `size` | `.file-thumbnail` |
+| `CameraView` | `streamUrl`, `snapshotUrl`, `status`, `printerName` | `.camera-feed` |
+| `StatusBadge` | `type` (printer/job/file), `status`, `label` | `.status-badge` |
+| `IdeaCard` | `idea` (id, title, platform, tags, thumbnailUrl, bookmarked) | `.idea-card` |
+| `MaterialCard` | `material` (id, name, color, type, remainingGrams) | `.material-card` |
+| `PageHeader` | `title`, `subtitle`, `breadcrumb`, `actions` | `.page-header` |
+| `PrinterTypeIcon` | `type` (bambu/prusa), `size` (sm/md/lg) | inline SVG |
+| `NavSidebar` | `items` (`{label, icon, href, active}[]`), `connectionStatus`, `appVersion` | `.nav-container .nav-link` |
+
+### Provider
+
+`PrinternizerProvider` — wraps designs, sets `data-theme` on its root `<div>`. Props: `theme` (default/refined/industrial/soft/retro/brutalist), `children`. Required wrapper for all components to render correctly.
+
+---
+
+## 4. CSS bundling
+
+`styles/entry.css` imports the existing Printernizer stylesheets in order:
+
+```css
+@import "../../css/main.css";
+@import "../../css/components.css";
+@import "../../css/dark-theme.css";
+@import "../../css/themes/theme-refined.css";
+@import "../../css/themes/theme-industrial.css";
+@import "../../css/themes/theme-soft.css";
+@import "../../css/themes/theme-retro.css";
+@import "../../css/themes/theme-brutalist.css";
+```
+
+esbuild bundles this to `dist/styles.css`. Components never import CSS themselves — all styling comes from this single entry. This guarantees visual fidelity to the live app with zero maintenance burden on the design system side.
+
+---
+
+## 5. Build setup
+
+**`package.json` scripts:**
+- `build` — runs `build.mjs` via Node; produces `dist/index.js` (ESM) and `dist/styles.css`
+- `typecheck` — `tsc --noEmit`
+
+**`build.mjs` (esbuild):**
+- Entry: `src/index.ts`
+- Format: ESM
+- Global name (for design-sync bundle header): `PrinternizerDS`
+- External: `react`, `react-dom`
+- Bundle: true
+- Minify: false (readable output aids design agent)
+- CSS entry: `styles/entry.css` → `dist/styles.css` (separate esbuild pass)
+
+**TypeScript config:**
+- `strict: true`
+- `jsx: "react-jsx"`
+- `declaration: true` (generates `.d.ts` alongside `dist/index.js`)
+- `moduleResolution: "bundler"`
+
+---
+
+## 6. Design-sync integration
+
+After the component library builds cleanly, `/design-sync` is run from `frontend/react-ds/`. The sync skill:
+1. Detects shape: `package` (no Storybook)
+2. Bundles `dist/index.js` + `dist/styles.css` into the claude.ai/design upload format
+3. Generates `.d.ts`-derived type docs and `.prompt.md` usage guides per component
+4. Captures HTML preview cards per component
+5. Uploads to a new claude.ai/design project named "Printernizer Design System"
+
+The conventions header (authored post-sync) will instruct the design agent to:
+- Always wrap in `<PrinternizerProvider theme="default">`
+- Never write custom CSS classes for Printernizer UI patterns — use the named components
+- Use CSS variables (`var(--primary-color)`, etc.) only for layout glue that has no named component
+
+---
+
+## 7. Out of scope
+
+- Migrating the live Printernizer frontend from vanilla JS to React (this is a design system only)
+- Server-side rendering
+- Storybook
+- npm publish
+- Dark mode toggle component (dark theme CSS is bundled; toggling it is out of scope for the design system)
+- Additional page CSS files (dashboard.css, library.css, etc.) — only `main.css` and `components.css` are needed for the component library; page-level layout CSS is not component-scoped

--- a/frontend/react-ds/.design-sync/NOTES.md
+++ b/frontend/react-ds/.design-sync/NOTES.md
@@ -1,0 +1,41 @@
+# Printernizer Design System — Sync Notes
+
+## Setup
+
+- Shape: `package` (no Storybook)
+- Entry: `dist/index.js` (esbuild ESM)
+- CSS: `dist/styles.css` (bundled from all theme files + main + components + materials)
+- `.d.ts` generation: tsconfig has `noEmit: true` — run `npx tsc --declaration --emitDeclarationOnly --outDir dist --noEmit false` before the converter. This is required; without it the converter finds 0 components.
+- PlayWright version: `1228` — matches `~/.cache/ms-playwright/chromium-1228`
+
+## Known render warns
+
+- `[TOKENS_MISSING]` 70 CSS custom properties — Printernizer defines its CSS vars in `main.css`/`components.css` (always bundled). The tokens that are "missing" in static analysis are theme-specific vars defined in the theme CSS files. Since `PrinternizerProvider` wraps all previews and the CSS is bundled in, rendered previews look correct. Not a real issue.
+- `[FONT_REMOTE]` — Space Mono, DM Sans, etc. are loaded from Google Fonts via a remote @import in the Printernizer CSS. Expected behavior.
+
+## Re-sync procedure
+
+```bash
+cd frontend/react-ds
+
+# 1. Rebuild the component library
+npm run build
+
+# 2. Generate .d.ts (REQUIRED — noEmit:true means tsc won't do this automatically)
+npx tsc --declaration --emitDeclarationOnly --outDir dist --noEmit false
+
+# 3. Stage converter scripts (re-copy on every sync to get latest converter)
+SKILL_BASE="/tmp/claude-1000/bundled-skills/2.1.187/5e7097dfd7a2ae64a3299b8dfb4b194e/design-sync"
+cp -r "$SKILL_BASE/package-build.mjs" "$SKILL_BASE/package-validate.mjs" "$SKILL_BASE/package-capture.mjs" "$SKILL_BASE/resync.mjs" "$SKILL_BASE/lib" "$SKILL_BASE/storybook" .ds-sync/
+
+# 4. Run the resync driver
+node .ds-sync/resync.mjs --config .design-sync/config.json --node-modules ./node_modules --entry ./dist/index.js --out ./ds-bundle --remote .design-sync/.cache/remote-sync.json
+```
+
+## Re-sync risks
+
+- **`.d.ts` generation step**: must be run manually before every sync — the build.mjs doesn't emit declarations. If skipped, converter finds 0 components.
+- **Skill base path**: The SKILL_BASE path `/tmp/claude-1000/bundled-skills/...` is session-specific. On re-sync, find the current path by checking available bundled skills.
+- **Authored previews** (`.design-sync/previews/*.tsx`): Input, StatCard, IdeaCard, JobListItem, PrintProgressBar. These are committed and carry forward. Re-sync will pick them up automatically.
+- **10 floor-card components**: these have no authored previews and show the typographic floor card. They can be authored incrementally on any re-sync. Components: Alert, Badge, Breadcrumb, Button, Card, EmptyState, FormGroup, Modal, Pagination, SearchBox, Select, Table, Toast (core) + CameraView, FileListItem, FileThumbnail, MaterialCard, NavSidebar, PageHeader, PrinterCard, PrinterStatusBadge, PrinterTypeIcon, StatusBadge (domain) — minus the 5 authored above.
+- **NavSidebar naming**: despite the name, this component renders a horizontal top navigation bar (matching the actual Printernizer app). The design agent should be aware of this — it's documented in conventions.md.

--- a/frontend/react-ds/.design-sync/config.json
+++ b/frontend/react-ds/.design-sync/config.json
@@ -1,0 +1,18 @@
+{
+  "pkg": "@printernizer/design-system",
+  "globalName": "PrinternizerDS",
+  "projectId": "12d0cf4c-6461-4e62-a2a4-90f485804465",
+  "shape": "package",
+  "buildCmd": "npm run build",
+  "cssEntry": "dist/styles.css",
+  "provider": {
+    "component": "PrinternizerProvider",
+    "props": { "theme": "default" }
+  },
+  "readmeHeader": ".design-sync/conventions.md",
+  "overrides": {
+    "StatCard": { "cardMode": "column" },
+    "JobListItem": { "cardMode": "column" },
+    "PrintProgressBar": { "cardMode": "column" }
+  }
+}

--- a/frontend/react-ds/.design-sync/conventions.md
+++ b/frontend/react-ds/.design-sync/conventions.md
@@ -1,0 +1,21 @@
+# Printernizer Design System — Conventions
+
+Always wrap every design in `<PrinternizerProvider theme="default">`. This sets CSS custom properties for the default professional-blue theme. Six themes are available: `default`, `refined`, `industrial`, `soft`, `retro`, `brutalist`.
+
+Never write raw CSS classes or inline styles for UI patterns that have a named component. Use the components.
+
+For layout glue that has no component (spacing between sections, page grid), use CSS variables: `var(--spacing-4)`, `var(--gray-100)`, `var(--primary-color)`.
+
+## Component groups
+
+**Core** — generic, reusable: Button, Card, Badge, Alert, Modal, Toast, Input, Select, Table, Pagination, SearchBox, StatCard, Breadcrumb, EmptyState, FormGroup
+
+**Domain** — Printernizer-specific: PrinterCard, PrinterStatusBadge, JobListItem, PrintProgressBar, FileListItem, FileThumbnail, CameraView, StatusBadge, IdeaCard, MaterialCard, PageHeader, PrinterTypeIcon, NavSidebar
+
+## Key conventions
+
+- `Button` variants: `primary` (default CTA), `secondary` (secondary action), `success`/`warning`/`error` (status actions). No ghost variant.
+- `Badge` maps to printer/job status dots: use `variant="success"` for completed, `"warning"` for printing, `"error"` for errors, `"gray"` for idle.
+- `Table` uses `.professional-table` styling. Pass `columns` with `key` + `header`, and `data` as an array of records.
+- Domain components accept a single `printer`/`job`/`file`/`material`/`idea` data object — see each component's Props interface for the shape.
+- `NavSidebar` renders a horizontal top navigation bar (matches the Printernizer app's actual layout) despite its name.

--- a/frontend/react-ds/.design-sync/previews/IdeaCard.tsx
+++ b/frontend/react-ds/.design-sync/previews/IdeaCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IdeaCard } from '@printernizer/design-system';
+
+export const Default = () => (
+  <div style={{ padding: '1rem', width: 240 }}>
+    <IdeaCard
+      idea={{
+        id: '1',
+        title: 'Articulated Dragon',
+        platform: 'Printables',
+        tags: ['dragon', 'articulated', 'toy'],
+        status: 'idea',
+        bookmarked: true,
+      }}
+    />
+  </div>
+);
+
+export const Planned = () => (
+  <div style={{ padding: '1rem', display: 'flex', gap: '1rem' }}>
+    <IdeaCard
+      idea={{ id: '2', title: 'Cable Organizer', platform: 'Thingiverse', status: 'planned', tags: ['utility'] }}
+    />
+    <IdeaCard
+      idea={{ id: '3', title: 'Plant Pot', platform: 'Printables', status: 'archived', tags: ['home'] }}
+    />
+  </div>
+);

--- a/frontend/react-ds/.design-sync/previews/Input.tsx
+++ b/frontend/react-ds/.design-sync/previews/Input.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Input } from '@printernizer/design-system';
+
+export const TextInput = () => (
+  <div style={{ padding: '1rem', display: 'flex', flexDirection: 'column', gap: '1rem', width: 320 }}>
+    <Input label="Email address" type="email" placeholder="you@example.com" />
+    <Input label="Password" type="password" placeholder="Enter password" />
+    <Input label="Search" type="text" placeholder="Search printers..." prefix="🔍" />
+  </div>
+);
+
+export const WithError = () => (
+  <div style={{ padding: '1rem', width: 320 }}>
+    <Input label="File name" value="broken-file" error="File name contains invalid characters" hint="Use letters, numbers, and hyphens only" />
+  </div>
+);
+
+export const Required = () => (
+  <div style={{ padding: '1rem', width: 320 }}>
+    <Input label="Printer name" required placeholder="e.g. Bambu A1 Mini" hint="This will appear in job reports" />
+  </div>
+);

--- a/frontend/react-ds/.design-sync/previews/JobListItem.tsx
+++ b/frontend/react-ds/.design-sync/previews/JobListItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { JobListItem } from '@printernizer/design-system';
+
+export const Printing = () => (
+  <div style={{ padding: '1rem', width: 500 }}>
+    <JobListItem
+      job={{
+        id: 'j1',
+        name: 'Dragon_v3_final.3mf',
+        printer: 'Bambu A1 Mini',
+        progress: 67,
+        status: 'printing',
+        duration: '2h 34m',
+        startedAt: '2026-06-26T08:00:00Z',
+      }}
+    />
+  </div>
+);
+
+export const Completed = () => (
+  <div style={{ padding: '1rem', width: 500, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <JobListItem
+      job={{ id: 'j2', name: 'Cable_Clip.stl', printer: 'Prusa Core One', progress: 100, status: 'completed', duration: '45m', startedAt: '2026-06-26T06:00:00Z' }}
+    />
+    <JobListItem
+      job={{ id: 'j3', name: 'Phone_Stand.3mf', printer: 'Bambu A1', progress: 0, status: 'error', duration: '—', startedAt: '2026-06-26T07:30:00Z' }}
+    />
+  </div>
+);

--- a/frontend/react-ds/.design-sync/previews/PrintProgressBar.tsx
+++ b/frontend/react-ds/.design-sync/previews/PrintProgressBar.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { PrintProgressBar } from '@printernizer/design-system';
+
+export const Printing = () => (
+  <div style={{ padding: '1rem', width: 400, display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+    <PrintProgressBar progress={67} status="printing" timeRemaining="1h 12m remaining" />
+    <PrintProgressBar progress={100} status="completed" />
+    <PrintProgressBar progress={23} status="warning" timeRemaining="3h 45m remaining" />
+  </div>
+);
+
+export const Error = () => (
+  <div style={{ padding: '1rem', width: 400 }}>
+    <PrintProgressBar progress={45} status="error" />
+  </div>
+);

--- a/frontend/react-ds/.design-sync/previews/StatCard.tsx
+++ b/frontend/react-ds/.design-sync/previews/StatCard.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { StatCard } from '@printernizer/design-system';
+
+export const PrintJobsStat = () => (
+  <div style={{ padding: '1rem', display: 'grid', gridTemplateColumns: 'repeat(3, 180px)', gap: '1rem' }}>
+    <StatCard label="Print Jobs Today" value="24" delta="+3 from yesterday" icon="🖨" />
+    <StatCard label="Filament Used" value="847g" delta="-12% vs last week" icon="🧵" />
+    <StatCard label="Active Printers" value="3 / 5" icon="✅" />
+  </div>
+);
+
+export const Minimal = () => (
+  <div style={{ padding: '1rem' }}>
+    <StatCard label="Total Files" value="1,247" />
+  </div>
+);

--- a/frontend/react-ds/.gitignore
+++ b/frontend/react-ds/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/frontend/react-ds/.gitignore
+++ b/frontend/react-ds/.gitignore
@@ -1,2 +1,9 @@
 dist/
 node_modules/
+
+# design-sync artifacts
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules

--- a/frontend/react-ds/build.mjs
+++ b/frontend/react-ds/build.mjs
@@ -1,0 +1,27 @@
+import * as esbuild from 'esbuild';
+import { mkdirSync } from 'fs';
+
+mkdirSync('dist', { recursive: true });
+
+// JS bundle
+await esbuild.build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  format: 'esm',
+  outfile: 'dist/index.js',
+  external: ['react', 'react-dom', 'react/jsx-runtime'],
+  minify: false,
+  sourcemap: false,
+  target: ['es2020'],
+});
+
+// CSS bundle
+await esbuild.build({
+  entryPoints: ['styles/entry.css'],
+  bundle: true,
+  outfile: 'dist/styles.css',
+  loader: { '.css': 'css' },
+  minify: false,
+});
+
+console.log('Build complete: dist/index.js + dist/styles.css');

--- a/frontend/react-ds/package-lock.json
+++ b/frontend/react-ds/package-lock.json
@@ -1,0 +1,585 @@
+{
+  "name": "@printernizer/design-system",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@printernizer/design-system",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.5.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/frontend/react-ds/package.json
+++ b/frontend/react-ds/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@printernizer/design-system",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node build.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/frontend/react-ds/src/PrinternizerProvider/index.tsx
+++ b/frontend/react-ds/src/PrinternizerProvider/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export type PrinternizerTheme =
+  | 'default'
+  | 'refined'
+  | 'industrial'
+  | 'soft'
+  | 'retro'
+  | 'brutalist';
+
+export interface PrinternizerProviderProps {
+  theme?: PrinternizerTheme;
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function PrinternizerProvider({
+  theme = 'default',
+  children,
+  className,
+  style,
+}: PrinternizerProviderProps) {
+  return (
+    <div
+      data-theme={theme === 'default' ? undefined : theme}
+      className={className}
+      style={{ minHeight: '100%', ...style }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Alert/index.tsx
+++ b/frontend/react-ds/src/core/Alert/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
+
+export interface AlertProps {
+  variant?: AlertVariant;
+  title?: string;
+  message: React.ReactNode;
+  dismissible?: boolean;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function Alert({ variant = 'info', title, message, dismissible, onDismiss, className }: AlertProps) {
+  return (
+    <div className={['alert', `alert-${variant}`, className ?? ''].filter(Boolean).join(' ')}>
+      {title && <strong>{title} </strong>}
+      {message}
+      {dismissible && (
+        <button
+          onClick={onDismiss}
+          style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem' }}
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Badge/index.tsx
+++ b/frontend/react-ds/src/core/Badge/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export type BadgeVariant = 'success' | 'error' | 'warning' | 'info' | 'gray';
+
+const variantClass: Record<BadgeVariant, string> = {
+  success: 'status-completed',
+  error: 'status-error',
+  warning: 'status-printing',
+  info: 'status-online',
+  gray: 'status-idle',
+};
+
+export interface BadgeProps {
+  variant?: BadgeVariant;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Badge({ variant = 'gray', children, className }: BadgeProps) {
+  return (
+    <span className={['status-badge', variantClass[variant], className ?? ''].filter(Boolean).join(' ')}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/react-ds/src/core/Breadcrumb/index.tsx
+++ b/frontend/react-ds/src/core/Breadcrumb/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export function Breadcrumb({ items, className }: BreadcrumbProps) {
+  return (
+    <nav className={['breadcrumb-nav', className ?? ''].filter(Boolean).join(' ')} aria-label="Breadcrumb">
+      {items.map((item, i) => (
+        <React.Fragment key={i}>
+          {i > 0 && <span className="breadcrumb-separator">›</span>}
+          {item.href ? (
+            <a className="breadcrumb-back" href={item.href}>
+              {item.label}
+            </a>
+          ) : (
+            <span>{item.label}</span>
+          )}
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/react-ds/src/core/Button/index.tsx
+++ b/frontend/react-ds/src/core/Button/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'success' | 'warning' | 'error';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  icon?: React.ReactNode;
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+export function Button({
+  variant = 'primary',
+  size,
+  icon,
+  loading = false,
+  children,
+  className,
+  disabled,
+  ...rest
+}: ButtonProps) {
+  const classes = [
+    'btn',
+    `btn-${variant}`,
+    size === 'sm' ? 'btn-sm' : size === 'lg' ? 'btn-lg' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button className={classes} disabled={disabled || loading} {...rest}>
+      {icon && <span className="btn-icon">{icon}</span>}
+      {loading ? '...' : children}
+    </button>
+  );
+}

--- a/frontend/react-ds/src/core/Card/index.tsx
+++ b/frontend/react-ds/src/core/Card/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export interface CardProps {
+  header?: React.ReactNode;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  hoverable?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function Card({ header, icon, children, hoverable = false, className, style }: CardProps) {
+  return (
+    <div className={['card', hoverable ? 'hoverable' : '', className ?? ''].filter(Boolean).join(' ')} style={style}>
+      {(header || icon) && (
+        <div className="card-header">
+          {icon && <span className="card-icon">{icon}</span>}
+          {header && <h3>{header}</h3>}
+        </div>
+      )}
+      <div className="card-body">{children}</div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/EmptyState/index.tsx
+++ b/frontend/react-ds/src/core/EmptyState/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  message?: string;
+  action?: EmptyStateAction;
+  className?: string;
+}
+
+export function EmptyState({ icon, title, message, action, className }: EmptyStateProps) {
+  return (
+    <div className={['empty-state', className ?? ''].filter(Boolean).join(' ')}>
+      {icon && <div>{icon}</div>}
+      <h3>{title}</h3>
+      {message && <p>{message}</p>}
+      {action && (
+        <button className="btn btn-primary" onClick={action.onClick}>
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/FormGroup/index.tsx
+++ b/frontend/react-ds/src/core/FormGroup/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export interface FormGroupProps {
+  label?: string;
+  required?: boolean;
+  error?: string;
+  hint?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function FormGroup({ label, required, error, hint, children, className }: FormGroupProps) {
+  return (
+    <div className={['form-group', className ?? ''].filter(Boolean).join(' ')}>
+      {label && (
+        <label>
+          {label}
+          {required && <span style={{ color: 'var(--error-color)' }}> *</span>}
+        </label>
+      )}
+      {children}
+      {hint && !error && <small style={{ color: 'var(--gray-500)', display: 'block', marginTop: '0.25rem' }}>{hint}</small>}
+      {error && <small style={{ color: 'var(--error-color)', display: 'block', marginTop: '0.25rem' }}>{error}</small>}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Input/index.tsx
+++ b/frontend/react-ds/src/core/Input/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
+  label?: string;
+  error?: string;
+  hint?: string;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+}
+
+export function Input({ label, error, hint, prefix, suffix, className, required, ...rest }: InputProps) {
+  return (
+    <div className="form-group">
+      {label && (
+        <label>
+          {label}
+          {required && <span style={{ color: 'var(--error-color)' }}> *</span>}
+        </label>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        {prefix && <span>{prefix}</span>}
+        <input
+          className={['form-control', error ? 'error' : '', className ?? ''].filter(Boolean).join(' ')}
+          required={required}
+          {...rest}
+        />
+        {suffix && <span>{suffix}</span>}
+      </div>
+      {hint && !error && <small style={{ color: 'var(--gray-500)', display: 'block', marginTop: '0.25rem' }}>{hint}</small>}
+      {error && <small style={{ color: 'var(--error-color)', display: 'block', marginTop: '0.25rem' }}>{error}</small>}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Modal/index.tsx
+++ b/frontend/react-ds/src/core/Modal/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export type ModalSize = 'sm' | 'md' | 'lg';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: ModalSize;
+  footer?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Modal({ open, onClose, title, size = 'md', footer, children, className }: ModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="modal show" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className={['modal-content', size === 'lg' ? 'large' : '', className ?? ''].filter(Boolean).join(' ')}>
+        {title && (
+          <div className="modal-header">
+            <h3>{title}</h3>
+            <button className="modal-close" onClick={onClose} aria-label="Close">×</button>
+          </div>
+        )}
+        <div className="modal-body">{children}</div>
+        {footer && <div className="modal-footer">{footer}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Pagination/index.tsx
+++ b/frontend/react-ds/src/core/Pagination/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onChange: (page: number) => void;
+  className?: string;
+}
+
+export function Pagination({ page, totalPages, onChange, className }: PaginationProps) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  return (
+    <div className={['pagination', className ?? ''].filter(Boolean).join(' ')}>
+      <button
+        className="pagination-btn"
+        onClick={() => onChange(page - 1)}
+        disabled={page <= 1}
+      >
+        ‹
+      </button>
+      {pages.map((p) => (
+        <button
+          key={p}
+          className={['pagination-btn', p === page ? 'active' : ''].filter(Boolean).join(' ')}
+          onClick={() => onChange(p)}
+        >
+          {p}
+        </button>
+      ))}
+      <button
+        className="pagination-btn"
+        onClick={() => onChange(page + 1)}
+        disabled={page >= totalPages}
+      >
+        ›
+      </button>
+      <span className="pagination-info">
+        Page {page} of {totalPages}
+      </span>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/SearchBox/index.tsx
+++ b/frontend/react-ds/src/core/SearchBox/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export interface SearchBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear?: () => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export function SearchBox({ value, onChange, onClear, placeholder = 'Search…', className }: SearchBoxProps) {
+  return (
+    <div className={['search-controls', className ?? ''].filter(Boolean).join(' ')}>
+      <div className="search-input-wrapper">
+        <span className="search-icon">🔍</span>
+        <input
+          type="search"
+          className="search-input"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+        />
+        {value && (
+          <button className="search-clear-btn" onClick={() => { onChange(''); onClear?.(); }} aria-label="Clear search">
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Select/index.tsx
+++ b/frontend/react-ds/src/core/Select/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  label?: string;
+  options: SelectOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  error?: string;
+  placeholder?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Select({ label, options, value, onChange, error, placeholder, required, disabled, className }: SelectProps) {
+  return (
+    <div className="form-group">
+      {label && (
+        <label>
+          {label}
+          {required && <span style={{ color: 'var(--error-color)' }}> *</span>}
+        </label>
+      )}
+      <select
+        className={['form-control', error ? 'error' : '', className ?? ''].filter(Boolean).join(' ')}
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+        required={required}
+        disabled={disabled}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error && <small style={{ color: 'var(--error-color)', display: 'block', marginTop: '0.25rem' }}>{error}</small>}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/StatCard/index.tsx
+++ b/frontend/react-ds/src/core/StatCard/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface StatCardProps {
+  label: string;
+  value: React.ReactNode;
+  delta?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function StatCard({ label, value, delta, icon, className }: StatCardProps) {
+  return (
+    <div className={['stat-card', className ?? ''].filter(Boolean).join(' ')}>
+      {icon && <div className="stat-icon">{icon}</div>}
+      <div className="stat-value">{value}</div>
+      <div className="stat-label">{label}</div>
+      {delta && <div className="stat-delta">{delta}</div>}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Table/index.tsx
+++ b/frontend/react-ds/src/core/Table/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export interface TableColumn<T> {
+  key: keyof T;
+  header: string;
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+  sortable?: boolean;
+}
+
+export interface TableProps<T extends Record<string, unknown>> {
+  columns: TableColumn<T>[];
+  data: T[];
+  loading?: boolean;
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function Table<T extends Record<string, unknown>>({
+  columns,
+  data,
+  loading,
+  emptyMessage = 'No data',
+  className,
+}: TableProps<T>) {
+  return (
+    <div className={['table-container', className ?? ''].filter(Boolean).join(' ')}>
+      <table className="professional-table">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th key={String(col.key)}>{col.header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: 'center', padding: '2rem' }}>
+                Loading…
+              </td>
+            </tr>
+          ) : data.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: 'center', padding: '2rem', color: 'var(--gray-500)' }}>
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            data.map((row, rowIdx) => (
+              <tr key={rowIdx}>
+                {columns.map((col) => (
+                  <td key={String(col.key)}>
+                    {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/core/Toast/index.tsx
+++ b/frontend/react-ds/src/core/Toast/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export type ToastVariant = 'success' | 'warning' | 'error' | 'info';
+
+export interface ToastProps {
+  variant?: ToastVariant;
+  title?: string;
+  message: React.ReactNode;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function Toast({ variant = 'info', title, message, onDismiss, className }: ToastProps) {
+  return (
+    <div className={['toast', `toast-${variant}`, className ?? ''].filter(Boolean).join(' ')}>
+      <div className="toast-header">
+        {title && <span className="toast-title">{title}</span>}
+        {onDismiss && (
+          <button className="toast-close" onClick={onDismiss} aria-label="Close">
+            ×
+          </button>
+        )}
+      </div>
+      <div className="toast-body">{message}</div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/CameraView/index.tsx
+++ b/frontend/react-ds/src/domain/CameraView/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export type CameraStatus = 'active' | 'inactive' | 'error';
+
+export interface CameraViewProps {
+  streamUrl?: string;
+  snapshotUrl?: string;
+  status: CameraStatus;
+  printerName?: string;
+  onSnapshot?: () => void;
+  className?: string;
+}
+
+export function CameraView({ streamUrl, snapshotUrl, status, printerName, onSnapshot, className }: CameraViewProps) {
+  return (
+    <div className={['camera-section', className ?? ''].filter(Boolean).join(' ')}>
+      {status === 'active' && streamUrl ? (
+        <div className="camera-preview-container">
+          <img
+            src={streamUrl}
+            alt={printerName ? `${printerName} camera` : 'Camera feed'}
+            className="camera-stream"
+          />
+        </div>
+      ) : (
+        <div className="camera-placeholder">
+          <span className="placeholder-icon">📷</span>
+          <span className="placeholder-text">
+            {status === 'error' ? 'Camera unavailable' : 'No camera feed'}
+          </span>
+          {printerName && <small>{printerName}</small>}
+        </div>
+      )}
+      {onSnapshot && status === 'active' && (
+        <div className="camera-controls">
+          <button className="btn btn-secondary btn-sm" onClick={onSnapshot}>
+            📸 Snapshot
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/FileListItem/index.tsx
+++ b/frontend/react-ds/src/domain/FileListItem/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { FileThumbnail } from '../FileThumbnail';
+import type { FileType } from '../FileThumbnail';
+
+export interface FileData {
+  id: string;
+  name: string;
+  size: string;
+  type: FileType;
+  thumbnailUrl?: string;
+  uploadedAt?: string;
+}
+
+export interface FileListItemProps {
+  file: FileData;
+  onClick?: (fileId: string) => void;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function FileListItem({ file, onClick, actions, className }: FileListItemProps) {
+  return (
+    <div
+      className={['file-item', className ?? ''].filter(Boolean).join(' ')}
+      onClick={() => onClick?.(file.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <FileThumbnail src={file.thumbnailUrl} fileType={file.type} size="sm" alt={file.name} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600, color: 'var(--gray-900)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {file.name}
+        </div>
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--gray-500)' }}>
+          {file.size} {file.uploadedAt && `· ${file.uploadedAt}`}
+        </div>
+      </div>
+      {actions && <div onClick={(e) => e.stopPropagation()}>{actions}</div>}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/FileThumbnail/index.tsx
+++ b/frontend/react-ds/src/domain/FileThumbnail/index.tsx
@@ -19,7 +19,7 @@ export function FileThumbnail({ src, fileType, animated, size = 'md', alt, class
   const px = sizePx[size];
   return (
     <div
-      className={['file-thumbnail', animated ? 'animated' : '', className ?? ''].filter(Boolean).join(' ')}
+      className={['file-thumbnail', animated ? 'supports-animation' : '', className ?? ''].filter(Boolean).join(' ')}
       style={{ width: px, height: px, flexShrink: 0 }}
     >
       {src ? (

--- a/frontend/react-ds/src/domain/FileThumbnail/index.tsx
+++ b/frontend/react-ds/src/domain/FileThumbnail/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export type FileType = 'stl' | '3mf' | 'gcode' | 'image';
+export type ThumbnailSize = 'sm' | 'md' | 'lg';
+
+export interface FileThumbnailProps {
+  src?: string;
+  fileType: FileType;
+  animated?: boolean;
+  size?: ThumbnailSize;
+  alt?: string;
+  className?: string;
+}
+
+const sizePx: Record<ThumbnailSize, number> = { sm: 48, md: 80, lg: 128 };
+const typeEmoji: Record<FileType, string> = { stl: '🧊', '3mf': '🖨', gcode: '📄', image: '🖼' };
+
+export function FileThumbnail({ src, fileType, animated, size = 'md', alt, className }: FileThumbnailProps) {
+  const px = sizePx[size];
+  return (
+    <div
+      className={['file-thumbnail', animated ? 'animated' : '', className ?? ''].filter(Boolean).join(' ')}
+      style={{ width: px, height: px, flexShrink: 0 }}
+    >
+      {src ? (
+        <img src={src} alt={alt ?? fileType} style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: 'var(--radius-md)' }} />
+      ) : (
+        <span style={{ fontSize: px * 0.5, display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+          {typeEmoji[fileType]}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/IdeaCard/index.tsx
+++ b/frontend/react-ds/src/domain/IdeaCard/index.tsx
@@ -24,7 +24,7 @@ export function IdeaCard({ idea, onClick, onBookmark, className }: IdeaCardProps
     <div
       className={['idea-card', className ?? ''].filter(Boolean).join(' ')}
       onClick={() => onClick?.(idea.id)}
-      style={{ cursor: onClick ? 'pointer' : 'default' }}
+      style={{ cursor: onClick ? 'pointer' : 'default', position: 'relative' }}
     >
       {idea.thumbnailUrl && (
         <img

--- a/frontend/react-ds/src/domain/IdeaCard/index.tsx
+++ b/frontend/react-ds/src/domain/IdeaCard/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { StatusBadge } from '../StatusBadge';
+import type { IdeaStatus } from '../StatusBadge';
+
+export interface IdeaData {
+  id: string;
+  title: string;
+  platform?: string;
+  tags?: string[];
+  thumbnailUrl?: string;
+  bookmarked?: boolean;
+  status?: IdeaStatus;
+}
+
+export interface IdeaCardProps {
+  idea: IdeaData;
+  onClick?: (ideaId: string) => void;
+  onBookmark?: (ideaId: string, bookmarked: boolean) => void;
+  className?: string;
+}
+
+export function IdeaCard({ idea, onClick, onBookmark, className }: IdeaCardProps) {
+  return (
+    <div
+      className={['idea-card', className ?? ''].filter(Boolean).join(' ')}
+      onClick={() => onClick?.(idea.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      {idea.thumbnailUrl && (
+        <img
+          src={idea.thumbnailUrl}
+          alt={idea.title}
+          style={{ width: '100%', aspectRatio: '4/3', objectFit: 'cover' }}
+        />
+      )}
+      <div style={{ padding: '0.75rem' }}>
+        <div style={{ fontWeight: 600, color: 'var(--gray-900)', marginBottom: '0.25rem' }}>{idea.title}</div>
+        {idea.platform && (
+          <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--gray-500)', marginBottom: '0.5rem' }}>
+            {idea.platform}
+          </div>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          {idea.status && <StatusBadge status={idea.status} />}
+          {idea.tags?.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      </div>
+      {onBookmark && (
+        <button
+          className="btn btn-secondary btn-sm"
+          style={{ position: 'absolute', top: '0.5rem', right: '0.5rem' }}
+          onClick={(e) => { e.stopPropagation(); onBookmark(idea.id, !idea.bookmarked); }}
+          aria-label={idea.bookmarked ? 'Remove bookmark' : 'Bookmark'}
+        >
+          {idea.bookmarked ? '★' : '☆'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/JobListItem/index.tsx
+++ b/frontend/react-ds/src/domain/JobListItem/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { PrinterStatus } from '../PrinterStatusBadge';
+
+export interface JobData {
+  id: string;
+  name: string;
+  printer: string;
+  progress: number;
+  status: PrinterStatus;
+  duration?: string;
+  startedAt?: string;
+}
+
+export interface JobListItemProps {
+  job: JobData;
+  onClick?: (jobId: string) => void;
+  className?: string;
+}
+
+const jobStatusClass: Record<PrinterStatus, string> = {
+  printing: 'status-printing',
+  idle: 'status-idle',
+  error: 'status-error',
+  offline: 'status-offline',
+  connecting: 'status-idle',
+};
+
+export function JobListItem({ job, onClick, className }: JobListItemProps) {
+  return (
+    <div
+      className={['file-item', className ?? ''].filter(Boolean).join(' ')}
+      onClick={() => onClick?.(job.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flex: 1 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontWeight: 600, color: 'var(--gray-900)' }}>{job.name}</div>
+          <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--gray-500)' }}>
+            {job.printer} {job.startedAt && `· ${job.startedAt}`}
+          </div>
+        </div>
+        {job.status === 'printing' && (
+          <div style={{ width: 120 }}>
+            <div className="progress">
+              <div className="progress-bar" style={{ width: `${job.progress}%` }} />
+            </div>
+            <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--gray-500)', marginTop: '0.25rem' }}>
+              {job.progress}%
+            </div>
+          </div>
+        )}
+        <span className={`status-badge ${jobStatusClass[job.status]}`}>
+          {job.status}
+        </span>
+        {job.duration && (
+          <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--gray-500)' }}>{job.duration}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/MaterialCard/index.tsx
+++ b/frontend/react-ds/src/domain/MaterialCard/index.tsx
@@ -46,17 +46,19 @@ export function MaterialCard({ material, onClick, className }: MaterialCardProps
         <span className="material-type-badge">{material.type}</span>
       </div>
       <div className="material-info">
-        {material.remainingGrams !== undefined && (
-          <div className="material-detail-item">
-            <span className="material-detail-label">Remaining</span>
-            <span className="material-detail-value">{material.remainingGrams}g</span>
-          </div>
-        )}
-        {material.stockStatus && material.stockStatus !== 'ok' && (
-          <span className={['material-status-badge', material.stockStatus].join(' ')}>
-            {material.stockStatus === 'low' ? 'Low stock' : 'Out of stock'}
-          </span>
-        )}
+        <div className="material-details">
+          {material.remainingGrams !== undefined && (
+            <div className="material-detail-item">
+              <span className="material-detail-label">Remaining</span>
+              <span className="material-detail-value">{material.remainingGrams}g</span>
+            </div>
+          )}
+          {material.stockStatus && material.stockStatus !== 'ok' && (
+            <span className={['material-status-badge', material.stockStatus].join(' ')}>
+              {material.stockStatus === 'low' ? 'Low stock' : 'Out of stock'}
+            </span>
+          )}
+        </div>
       </div>
       {pct !== undefined && (
         <div className="material-progress">

--- a/frontend/react-ds/src/domain/MaterialCard/index.tsx
+++ b/frontend/react-ds/src/domain/MaterialCard/index.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+export type MaterialStockStatus = 'ok' | 'low' | 'out';
+
+export interface MaterialData {
+  id: string;
+  name: string;
+  color: string;
+  type: string;
+  remainingGrams?: number;
+  totalGrams?: number;
+  stockStatus?: MaterialStockStatus;
+}
+
+export interface MaterialCardProps {
+  material: MaterialData;
+  onClick?: (materialId: string) => void;
+  className?: string;
+}
+
+export function MaterialCard({ material, onClick, className }: MaterialCardProps) {
+  const pct =
+    material.remainingGrams !== undefined && material.totalGrams
+      ? Math.round((material.remainingGrams / material.totalGrams) * 100)
+      : undefined;
+
+  return (
+    <div
+      className={[
+        'material-card',
+        material.stockStatus === 'low' ? 'low-stock' : '',
+        material.stockStatus === 'out' ? 'out-of-stock' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={() => onClick?.(material.id)}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <div className="material-card-header">
+        <span
+          className="material-color-indicator"
+          style={{ backgroundColor: material.color, width: 16, height: 16, borderRadius: '50%', display: 'inline-block', marginRight: '0.5rem' }}
+        />
+        <span className="material-name">{material.name}</span>
+        <span className="material-type-badge">{material.type}</span>
+      </div>
+      <div className="material-info">
+        {material.remainingGrams !== undefined && (
+          <div className="material-detail-item">
+            <span className="material-detail-label">Remaining</span>
+            <span className="material-detail-value">{material.remainingGrams}g</span>
+          </div>
+        )}
+        {material.stockStatus && material.stockStatus !== 'ok' && (
+          <span className={['material-status-badge', material.stockStatus].join(' ')}>
+            {material.stockStatus === 'low' ? 'Low stock' : 'Out of stock'}
+          </span>
+        )}
+      </div>
+      {pct !== undefined && (
+        <div className="material-progress">
+          <div className="progress">
+            <div className="progress-bar" style={{ width: `${pct}%` }} />
+          </div>
+          <span className="material-progress-label">{pct}%</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/NavSidebar/index.tsx
+++ b/frontend/react-ds/src/domain/NavSidebar/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+export type ConnectionStatus = 'connected' | 'disconnected' | 'connecting';
+
+export interface NavItem {
+  label: string;
+  icon?: React.ReactNode;
+  href: string;
+  active?: boolean;
+}
+
+export interface NavSidebarProps {
+  items: NavItem[];
+  connectionStatus?: ConnectionStatus;
+  appVersion?: string;
+  className?: string;
+}
+
+export function NavSidebar({ items, connectionStatus, appVersion, className }: NavSidebarProps) {
+  return (
+    <nav className={['nav-container', className ?? ''].filter(Boolean).join(' ')}>
+      <div className="nav-brand">Printernizer</div>
+      <ul className="nav-menu" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {items.map((item) => (
+          <li key={item.href}>
+            <a
+              href={item.href}
+              className={['nav-link', item.active ? 'active' : ''].filter(Boolean).join(' ')}
+            >
+              {item.icon && <span className="nav-icon">{item.icon}</span>}
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+      {connectionStatus && (
+        <div className="nav-status" style={{ padding: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span className={`status-dot ${connectionStatus}`} />
+          <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--gray-500)' }}>
+            {connectionStatus === 'connected' ? 'Connected' : connectionStatus === 'connecting' ? 'Connecting…' : 'Disconnected'}
+          </span>
+        </div>
+      )}
+      {appVersion && (
+        <div style={{ padding: '0 1rem 1rem', fontSize: 'var(--font-size-xs)', color: 'var(--gray-400)' }}>
+          v{appVersion}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/frontend/react-ds/src/domain/PageHeader/index.tsx
+++ b/frontend/react-ds/src/domain/PageHeader/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  breadcrumb?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function PageHeader({ title, subtitle, breadcrumb, actions, className }: PageHeaderProps) {
+  return (
+    <div className={['page-header', className ?? ''].filter(Boolean).join(' ')}>
+      {breadcrumb && <div className="page-breadcrumb">{breadcrumb}</div>}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <h1>{title}</h1>
+          {subtitle && <p style={{ color: 'var(--gray-500)', marginBottom: 0 }}>{subtitle}</p>}
+        </div>
+        {actions && <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/PrintProgressBar/index.tsx
+++ b/frontend/react-ds/src/domain/PrintProgressBar/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export type ProgressStatus = 'printing' | 'success' | 'error' | 'warning';
+
+export interface PrintProgressBarProps {
+  progress: number;
+  status?: ProgressStatus;
+  timeRemaining?: string;
+  label?: string;
+  className?: string;
+}
+
+const statusClass: Record<ProgressStatus, string> = {
+  printing: 'progress-animated',
+  success: 'progress-success',
+  error: 'progress-error',
+  warning: 'progress-warning',
+};
+
+export function PrintProgressBar({ progress, status = 'printing', timeRemaining, label, className }: PrintProgressBarProps) {
+  const clamped = Math.max(0, Math.min(100, progress));
+  return (
+    <div className={['progress-wrapper', statusClass[status], className ?? ''].filter(Boolean).join(' ')}>
+      {(label || timeRemaining) && (
+        <div className="progress-header">
+          {label && <span className="progress-label">{label}</span>}
+          {timeRemaining && <span className="progress-details">{timeRemaining}</span>}
+        </div>
+      )}
+      <div className="progress">
+        <div
+          className="progress-bar"
+          style={{ width: `${clamped}%` }}
+          role="progressbar"
+          aria-valuenow={clamped}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/PrinterCard/index.tsx
+++ b/frontend/react-ds/src/domain/PrinterCard/index.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { PrinterStatusBadge } from '../PrinterStatusBadge';
+import type { PrinterStatus } from '../PrinterStatusBadge';
+import { PrinterTypeIcon } from '../PrinterTypeIcon';
+import type { PrinterType } from '../PrinterTypeIcon';
+import { PrintProgressBar } from '../PrintProgressBar';
+
+export interface PrinterData {
+  id: string;
+  name: string;
+  status: PrinterStatus;
+  printerType: PrinterType;
+  cameraUrl?: string;
+  progress?: number;
+  currentFile?: string;
+  timeRemaining?: string;
+}
+
+export interface PrinterCardProps {
+  printer: PrinterData;
+  onAction?: (action: 'pause' | 'resume' | 'cancel' | 'settings', printerId: string) => void;
+  monitoring?: boolean;
+  className?: string;
+}
+
+export function PrinterCard({ printer, onAction, monitoring = false, className }: PrinterCardProps) {
+  return (
+    <div
+      className={[
+        'card',
+        'printer-card',
+        monitoring ? 'monitoring-active' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="card-header">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <PrinterTypeIcon type={printer.printerType} size="md" />
+          <div>
+            <h3 style={{ margin: 0, fontSize: 'var(--font-size-base)', fontWeight: 600 }}>{printer.name}</h3>
+            <PrinterStatusBadge status={printer.status} />
+          </div>
+        </div>
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={() => onAction?.('settings', printer.id)}
+          aria-label="Printer settings"
+        >
+          ⚙
+        </button>
+      </div>
+      <div className="card-body">
+        {printer.cameraUrl ? (
+          <img
+            src={printer.cameraUrl}
+            alt={`${printer.name} camera`}
+            style={{ width: '100%', borderRadius: 'var(--radius-md)', marginBottom: '1rem' }}
+          />
+        ) : (
+          <div className="camera-placeholder">
+            <span className="camera-icon">📷</span>
+            <span className="camera-text">No camera</span>
+          </div>
+        )}
+        {printer.status === 'printing' && printer.progress !== undefined && (
+          <PrintProgressBar
+            progress={printer.progress}
+            status="printing"
+            label={printer.currentFile}
+            timeRemaining={printer.timeRemaining}
+          />
+        )}
+        {printer.status === 'printing' && (
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem' }}>
+            <button className="btn btn-warning btn-sm" onClick={() => onAction?.('pause', printer.id)}>
+              Pause
+            </button>
+            <button className="btn btn-error btn-sm" onClick={() => onAction?.('cancel', printer.id)}>
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-ds/src/domain/PrinterStatusBadge/index.tsx
+++ b/frontend/react-ds/src/domain/PrinterStatusBadge/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export type PrinterStatus = 'idle' | 'printing' | 'error' | 'offline' | 'connecting';
+
+export interface PrinterStatusBadgeProps {
+  status: PrinterStatus;
+  showLabel?: boolean;
+  className?: string;
+}
+
+const dotClass: Record<PrinterStatus, string> = {
+  idle: 'connected',
+  printing: 'connected',
+  error: 'disconnected',
+  offline: 'disconnected',
+  connecting: 'connecting',
+};
+
+const labels: Record<PrinterStatus, string> = {
+  idle: 'Idle',
+  printing: 'Printing',
+  error: 'Error',
+  offline: 'Offline',
+  connecting: 'Connecting',
+};
+
+export function PrinterStatusBadge({ status, showLabel = true, className }: PrinterStatusBadgeProps) {
+  return (
+    <span
+      className={['status-badge', `status-${status}`, className ?? ''].filter(Boolean).join(' ')}
+    >
+      <span className={`status-dot ${dotClass[status]}`} />
+      {showLabel && labels[status]}
+    </span>
+  );
+}

--- a/frontend/react-ds/src/domain/PrinterTypeIcon/index.tsx
+++ b/frontend/react-ds/src/domain/PrinterTypeIcon/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export type PrinterType = 'bambu' | 'prusa';
+export type IconSize = 'sm' | 'md' | 'lg';
+
+export interface PrinterTypeIconProps {
+  type: PrinterType;
+  size?: IconSize;
+  className?: string;
+}
+
+const sizePx: Record<IconSize, number> = { sm: 16, md: 24, lg: 32 };
+
+export function PrinterTypeIcon({ type, size = 'md', className }: PrinterTypeIconProps) {
+  const px = sizePx[size];
+
+  if (type === 'bambu') {
+    return (
+      <svg
+        width={px}
+        height={px}
+        viewBox="0 0 24 24"
+        fill="none"
+        className={className}
+        aria-label="Bambu Lab"
+      >
+        <rect width="24" height="24" rx="4" fill="#F97316" />
+        <text x="12" y="17" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold">B</text>
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width={px}
+      height={px}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-label="Prusa"
+    >
+      <rect width="24" height="24" rx="4" fill="#DC2626" />
+      <text x="12" y="17" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold">P</text>
+    </svg>
+  );
+}

--- a/frontend/react-ds/src/domain/StatusBadge/index.tsx
+++ b/frontend/react-ds/src/domain/StatusBadge/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export type IdeaStatus = 'idea' | 'planned' | 'printing' | 'completed' | 'archived';
+
+export interface StatusBadgeProps {
+  status: IdeaStatus;
+  label?: string;
+  className?: string;
+}
+
+export function StatusBadge({ status, label, className }: StatusBadgeProps) {
+  const displayLabel = label ?? status.charAt(0).toUpperCase() + status.slice(1);
+  return (
+    <span className={['status-badge', `status-${status}`, className ?? ''].filter(Boolean).join(' ')}>
+      {displayLabel}
+    </span>
+  );
+}

--- a/frontend/react-ds/src/index.ts
+++ b/frontend/react-ds/src/index.ts
@@ -6,3 +6,21 @@ export type { ButtonProps, ButtonVariant, ButtonSize } from './core/Button';
 
 export { Card } from './core/Card';
 export type { CardProps } from './core/Card';
+
+export { Badge } from './core/Badge';
+export type { BadgeProps, BadgeVariant } from './core/Badge';
+
+export { Alert } from './core/Alert';
+export type { AlertProps, AlertVariant } from './core/Alert';
+
+export { Toast } from './core/Toast';
+export type { ToastProps, ToastVariant } from './core/Toast';
+
+export { Breadcrumb } from './core/Breadcrumb';
+export type { BreadcrumbProps, BreadcrumbItem } from './core/Breadcrumb';
+
+export { EmptyState } from './core/EmptyState';
+export type { EmptyStateProps, EmptyStateAction } from './core/EmptyState';
+
+export { StatCard } from './core/StatCard';
+export type { StatCardProps } from './core/StatCard';

--- a/frontend/react-ds/src/index.ts
+++ b/frontend/react-ds/src/index.ts
@@ -1,2 +1,2 @@
-// components exported in later tasks
-export {};
+export { PrinternizerProvider } from './PrinternizerProvider';
+export type { PrinternizerProviderProps, PrinternizerTheme } from './PrinternizerProvider';

--- a/frontend/react-ds/src/index.ts
+++ b/frontend/react-ds/src/index.ts
@@ -1,0 +1,2 @@
+// components exported in later tasks
+export {};

--- a/frontend/react-ds/src/index.ts
+++ b/frontend/react-ds/src/index.ts
@@ -1,2 +1,8 @@
 export { PrinternizerProvider } from './PrinternizerProvider';
 export type { PrinternizerProviderProps, PrinternizerTheme } from './PrinternizerProvider';
+
+export { Button } from './core/Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './core/Button';
+
+export { Card } from './core/Card';
+export type { CardProps } from './core/Card';

--- a/frontend/react-ds/src/index.ts
+++ b/frontend/react-ds/src/index.ts
@@ -24,3 +24,63 @@ export type { EmptyStateProps, EmptyStateAction } from './core/EmptyState';
 
 export { StatCard } from './core/StatCard';
 export type { StatCardProps } from './core/StatCard';
+
+export { FormGroup } from './core/FormGroup';
+export type { FormGroupProps } from './core/FormGroup';
+
+export { Input } from './core/Input';
+export type { InputProps } from './core/Input';
+
+export { Select } from './core/Select';
+export type { SelectProps, SelectOption } from './core/Select';
+
+export { SearchBox } from './core/SearchBox';
+export type { SearchBoxProps } from './core/SearchBox';
+
+export { PageHeader } from './domain/PageHeader';
+export type { PageHeaderProps } from './domain/PageHeader';
+
+export { NavSidebar } from './domain/NavSidebar';
+export type { NavSidebarProps, NavItem, ConnectionStatus } from './domain/NavSidebar';
+
+export { PrinterStatusBadge } from './domain/PrinterStatusBadge';
+export type { PrinterStatusBadgeProps, PrinterStatus } from './domain/PrinterStatusBadge';
+
+export { StatusBadge } from './domain/StatusBadge';
+export type { StatusBadgeProps, IdeaStatus } from './domain/StatusBadge';
+
+export { PrinterTypeIcon } from './domain/PrinterTypeIcon';
+export type { PrinterTypeIconProps, PrinterType, IconSize } from './domain/PrinterTypeIcon';
+
+export { Modal } from './core/Modal';
+export type { ModalProps, ModalSize } from './core/Modal';
+
+export { Table } from './core/Table';
+export type { TableProps, TableColumn } from './core/Table';
+
+export { Pagination } from './core/Pagination';
+export type { PaginationProps } from './core/Pagination';
+
+export { PrintProgressBar } from './domain/PrintProgressBar';
+export type { PrintProgressBarProps, ProgressStatus } from './domain/PrintProgressBar';
+
+export { PrinterCard } from './domain/PrinterCard';
+export type { PrinterCardProps, PrinterData } from './domain/PrinterCard';
+
+export { FileThumbnail } from './domain/FileThumbnail';
+export type { FileThumbnailProps, FileType, ThumbnailSize } from './domain/FileThumbnail';
+
+export { JobListItem } from './domain/JobListItem';
+export type { JobListItemProps, JobData } from './domain/JobListItem';
+
+export { FileListItem } from './domain/FileListItem';
+export type { FileListItemProps, FileData } from './domain/FileListItem';
+
+export { CameraView } from './domain/CameraView';
+export type { CameraViewProps, CameraStatus } from './domain/CameraView';
+
+export { IdeaCard } from './domain/IdeaCard';
+export type { IdeaCardProps, IdeaData } from './domain/IdeaCard';
+
+export { MaterialCard } from './domain/MaterialCard';
+export type { MaterialCardProps, MaterialData, MaterialStockStatus } from './domain/MaterialCard';

--- a/frontend/react-ds/styles/entry.css
+++ b/frontend/react-ds/styles/entry.css
@@ -1,5 +1,6 @@
 @import "../../css/main.css";
 @import "../../css/components.css";
+@import "../../css/materials.css";
 @import "../../css/dark-theme.css";
 @import "../../css/themes/theme-refined.css";
 @import "../../css/themes/theme-industrial.css";

--- a/frontend/react-ds/styles/entry.css
+++ b/frontend/react-ds/styles/entry.css
@@ -1,0 +1,8 @@
+@import "../../css/main.css";
+@import "../../css/components.css";
+@import "../../css/dark-theme.css";
+@import "../../css/themes/theme-refined.css";
+@import "../../css/themes/theme-industrial.css";
+@import "../../css/themes/theme-soft.css";
+@import "../../css/themes/theme-retro.css";
+@import "../../css/themes/theme-brutalist.css";

--- a/frontend/react-ds/tsconfig.json
+++ b/frontend/react-ds/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds a new CSS-wrapper React component library at `frontend/react-ds/` — 29 components built from existing Printernizer CSS, with zero new styles
- Synced to claude.ai/design so the design agent builds new Printernizer screens with real components
- Includes build setup (esbuild, TypeScript strict), theme provider (6 themes), and design-sync config

## Components

**Core (15):** Button, Card, Badge, Alert, Modal, Toast, Input, Select, Table, Pagination, SearchBox, StatCard, Breadcrumb, EmptyState, FormGroup

**Domain (13):** PrinterCard, PrinterStatusBadge, JobListItem, PrintProgressBar, FileListItem, FileThumbnail, CameraView, StatusBadge, IdeaCard, MaterialCard, PageHeader, PrinterTypeIcon, NavSidebar

**Provider:** PrinternizerProvider (theme wrapper, sets `data-theme` for all 6 themes)

## claude.ai/design

Project: https://claude.ai/design/p/12d0cf4c-6461-4e62-a2a4-90f485804465

Re-sync procedure documented in `frontend/react-ds/.design-sync/NOTES.md`.

## Test plan

- [ ] `cd frontend/react-ds && npm run build` — produces `dist/index.js` + `dist/styles.css`
- [ ] `npm run typecheck` — exits 0 (strict TypeScript)
- [ ] Open claude.ai/design project and verify component cards appear in the DS pane
- [ ] Check that existing Printernizer frontend still works (this branch adds files only — no existing files modified except `.gitignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)