### PR TITLE
fix: library role exposure + metadata-error visibility (v2.41.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.1] - 2026-06-27
+
+### Fixed
+- **Library API now returns `role` / `parent_checksum`** for files. Phase 3a stored these but the read API filtered them out, so the frontend never saw `role='model'` and the model-centric detail view never opened on click. (This is the fix that makes the Phase 3b view actually work.)
+
+### Added
+- Library files now carry an `analysis_error` field (migration 037): when STL/3MF metadata extraction fails, the error is recorded on the file and exposed via the API instead of only going to stdout — so a failed preview/dimension extraction is diagnosable.
+- `docs/SLICER-SETUP.md` — how to connect the slicer service so `GET /api/v1/slicing` isn't empty (Docker Compose, or pointing the HA add-on at a slicer container).
+
 ## [2.41.0] - 2026-06-27
 
 ### Added

--- a/docs/SLICER-SETUP.md
+++ b/docs/SLICER-SETUP.md
@@ -1,0 +1,41 @@
+# Enabling slicing (the slicer service)
+
+Printernizer does **not** slice inside the main app — slicing runs in a **separate
+slicer service** (OrcaSlicer). If `GET /api/v1/slicing` returns `{"slicers": []}`,
+the app can't reach a slicer yet, and the model detail view's **Slice** panel will
+say *"No slicer/profile available."* Here's how to connect one.
+
+The slicer image is published, multi-arch (amd64 + arm64):
+`ghcr.io/schmacka/printernizer-slicer:latest`
+
+## Option A — Docker Compose (standalone)
+
+Already wired in `docker/docker-compose.yml` (the `slicer` service +
+`SLICER_SERVICE_URL=http://slicer:8001`). Just:
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+```
+
+The app auto-registers the slicer on startup and seeds built-in profiles
+(Bambu A1, Prusa CORE One).
+
+## Option B — Home Assistant add-on
+
+The HA add-on is a single container and can't run a sidecar, so the slicer runs as
+a **second container** the add-on points at. Two ways:
+
+1. **Run the slicer image anywhere on your network** (a NAS, a mini-PC, `docker run -d -p 8001:8001 ghcr.io/schmacka/printernizer-slicer:latest`), then in the **Printernizer add-on → Configuration**, set the slicer service URL to `http://<that-host>:8001`.
+2. **Companion add-on** (`ha-addon/printernizer-slicer/` in this repo) — publish it into the `printernizer-ha` add-on repo as a second add-on, install it, and point `SLICER_SERVICE_URL` at it (`http://<addon-host>:8001`).
+
+> Note: the slicer image needs glibc ≥ 2.38 (Ubuntu 24.04 base) and runs headless;
+> it works on amd64 and arm64 (Raspberry Pi 4/5 class).
+
+## Verify
+
+```bash
+curl http://<your-printernizer>:8000/api/v1/slicing      # should list 1 slicer
+```
+
+Once a slicer is registered, the **Slice** panel in a model's detail view will show
+the curated profiles and let you Slice / Slice & Print.

--- a/migrations/037_library_analysis_error.sql
+++ b/migrations/037_library_analysis_error.sql
@@ -1,0 +1,6 @@
+-- Migration: 037_library_analysis_error.sql
+-- Description: Add analysis_error to library_files so metadata-extraction failures
+--              are visible via the API (they otherwise only reach stdout).
+-- Date: 2026-06-27
+
+ALTER TABLE library_files ADD COLUMN analysis_error TEXT;

--- a/src/api/routers/library.py
+++ b/src/api/routers/library.py
@@ -51,6 +51,9 @@ class LibraryFileResponse(BaseModel):
     model_volume: Optional[float] = None
     surface_area: Optional[float] = None
     object_count: Optional[int] = None
+    role: Optional[str] = None
+    parent_checksum: Optional[str] = None
+    analysis_error: Optional[str] = None
     layer_height: Optional[float] = None
     first_layer_height: Optional[float] = None
     nozzle_diameter: Optional[float] = None

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.41.0")
+APP_VERSION = get_version(fallback="2.41.1")
 
 
 # Prometheus metrics - initialized once

--- a/src/services/library_service.py
+++ b/src/services/library_service.py
@@ -1018,18 +1018,24 @@ class LibraryService:
                                 # Extract and merge STL-specific metadata
                                 stl_fields = self._map_stl_metadata_to_db(stl_result)
                                 metadata_fields.update(stl_fields)
+                                metadata_fields['analysis_error'] = None  # clear any prior error
 
                                 logger.info("STL geometric metadata extracted",
                                            checksum=checksum[:16],
                                            stl_fields_added=len(stl_fields))
                             else:
+                                err = stl_result.get('error') or 'STL analysis returned no data'
+                                metadata_fields['analysis_error'] = f"STL analysis failed: {err}"
                                 logger.warning("STL analysis failed",
                                              checksum=checksum[:16],
                                              error=stl_result.get('error'))
                         except Exception as e:
+                            # Persist the error onto the record so it is visible via the API
+                            # (it otherwise only reaches stdout via structlog).
+                            metadata_fields['analysis_error'] = f"STL analysis exception: {str(e)}"
                             logger.error("Error during STL analysis",
                                        checksum=checksum[:16],
-                                       error=str(e))
+                                       error=str(e), exc_info=True)
 
                     # Generate thumbnail if file needs it (STL, gcode without embedded thumbnails)
                     if parse_result.get('needs_generation', False) and not metadata_fields.get('has_thumbnail'):


### PR DESCRIPTION
Fixes the Phase 3b 'model view never opens' bug (#1: API didn't return role), adds analysis_error visibility (#2), and docs/SLICER-SETUP.md (#3). 8 library tests pass.