### PR TITLE
fix: register slicer from .env on HA add-on (v2.41.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.2] - 2026-06-28
+
+### Fixed
+- **Slicer not detected on the Home Assistant add-on.** The add-on provides `SLICER_SERVICE_URL` via `/app/.env`, but the remote-slicer registration only read `os.environ` (which the add-on never populates), so `GET /api/v1/slicing` stayed empty even with the slicer add-on running and configured. Registration now also reads it from app settings (which load `.env`). Added a `slicer_service_url` setting.
+
 ## [2.41.1] - 2026-06-27
 
 ### Fixed

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.41.1")
+APP_VERSION = get_version(fallback="2.41.2")
 
 
 # Prometheus metrics - initialized once

--- a/src/services/slicer_service.py
+++ b/src/services/slicer_service.py
@@ -515,9 +515,14 @@ class SlicerService(BaseService):
         return is_valid
 
     async def register_remote_slicer_from_env(self) -> None:
-        """Register the remote slicer service from SLICER_SERVICE_URL (idempotent)."""
+        """Register the remote slicer service from SLICER_SERVICE_URL (idempotent).
+
+        Reads from the process env (docker-compose) OR the app settings, which load
+        the HA add-on's .env file (the add-on writes SLICER_SERVICE_URL there, not
+        into os.environ).
+        """
         import os
-        url = os.environ.get("SLICER_SERVICE_URL")
+        url = os.environ.get("SLICER_SERVICE_URL") or getattr(self.settings, "slicer_service_url", "")
         if not url:
             return
         for s in await self.list_slicers():

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -90,6 +90,12 @@ class PrinternizerSettings(BaseSettings):
         description="Automatically create jobs when print starts are detected."
     )
 
+    slicer_service_url: str = Field(
+        default="",
+        env="SLICER_SERVICE_URL",
+        description="URL of the remote slicer microservice (e.g. http://slicer:8001). Empty disables slicing."
+    )
+
     # File Management
     downloads_path: str = Field(
         default="/data/printernizer/printer-files",


### PR DESCRIPTION
The HA add-on writes SLICER_SERVICE_URL to /app/.env (loaded by pydantic-settings, not os.environ); registration only read os.environ, so the slicer was never detected on HA. Now reads from settings too. Registration test passes.