### PR TITLE
fix: slice-from-library path + restore model-view Delete/Download/info (v2.41.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.3] - 2026-06-29
+
+### Fixed
+- **Slicing failed with "Library file not found".** The slice queue resolved the input via `file_path`, but library records store a relative `library_path` under the library root, so every slice-from-library failed. It now resolves the path robustly (relative `library_path` joined with the library root).
+- **Model detail view lost actions/info.** The model-centric view (added in 2.41.0) dropped the Delete and Download actions and the metadata display that the classic file view had. Restored: a **Delete** button (with refresh), a **Download** button, a metadata section (type/dimensions/size/source/added/checksum), and the `analysis_error` (when extraction failed) so a broken preview is visible in the UI.
+
+### Changed
+- `window.libraryManager` is now exposed so the model detail view can refresh the grid after deleting.
+
 ## [2.41.2] - 2026-06-28
 
 ### Fixed

--- a/frontend/js/library.js
+++ b/frontend/js/library.js
@@ -1529,6 +1529,7 @@ class LibraryManager {
 
 // Initialize library manager
 const libraryManager = new LibraryManager();
+window.libraryManager = libraryManager;  // expose for model-detail view (refresh after delete)
 
 // Export init function for page manager
 libraryManager.init = function() {

--- a/frontend/js/model-detail.js
+++ b/frontend/js/model-detail.js
@@ -45,10 +45,27 @@ class ModelDetailView {
             const model = await res.json();
             c.innerHTML = this._renderShell(model);
             c.querySelector('[data-act="back"]').addEventListener('click', () => this.close());
+            const delBtn = c.querySelector('[data-act="delete"]');
+            if (delBtn) delBtn.addEventListener('click', () => this._delete(model.display_name || model.filename || model.checksum));
             await this.refreshPrintfiles();
             await this.renderSlicePanel();
         } catch (e) {
             c.innerHTML = '<div class="error">Failed to load model.</div>';
+        }
+    }
+
+    async _delete(label) {
+        if (!confirm(`Delete "${label}"?\nThis removes the model from the library.`)) return;
+        try {
+            const r = await fetch(`${CONFIG.API_BASE_URL}/library/files/${this.checksum}`, { method: 'DELETE' });
+            if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || 'delete failed');
+            showToast('success', 'Library', 'Model deleted');
+            this.close();
+            if (window.libraryManager && typeof window.libraryManager.loadFiles === 'function') {
+                window.libraryManager.loadFiles();
+            }
+        } catch (e) {
+            showToast('error', 'Delete', e.message);
         }
     }
 
@@ -65,6 +82,24 @@ class ModelDetailView {
         const dims = (model.model_width && model.model_height)
             ? `${Math.round(model.model_width)}×${Math.round(model.model_depth || 0)}×${Math.round(model.model_height)} mm`
             : '';
+        const fmtBytes = (b) => {
+            if (b === null || b === undefined || b === '') return '';
+            const u = ['B', 'KB', 'MB', 'GB']; let i = 0, n = Number(b);
+            while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+            return `${n.toFixed(i ? 1 : 0)} ${u[i]}`;
+        };
+        const rows = [
+            ['Type', model.file_type || ''],
+            ['Dimensions', dims],
+            ['Size', fmtBytes(model.file_size)],
+            ['Source', model.sources || ''],
+            ['Added', (model.added_to_library || '').slice(0, 10)],
+            ['Checksum', model.checksum ? model.checksum.slice(0, 12) + '…' : ''],
+        ].filter(([, v]) => v);
+        const info = rows.map(([k, v]) => `<div class="md-info-row"><span class="md-info-k">${k}</span><span class="md-info-v">${v}</span></div>`).join('');
+        const err = model.analysis_error
+            ? `<div class="md-info-row md-info-error"><span class="md-info-k">Analysis</span><span class="md-info-v">${model.analysis_error}</span></div>`
+            : '';
         return `
           <div class="model-detail-header">
             <button class="btn btn-secondary" data-act="back">← Library</button>
@@ -72,8 +107,13 @@ class ModelDetailView {
             <div class="model-detail-title">
               <h2>${name}</h2>
               <div class="model-detail-meta">${dims}${dims ? ' · ' : ''}${model.file_type || ''}</div>
+              <div class="model-detail-actions">
+                <a class="btn btn-secondary" href="${CONFIG.API_BASE_URL}/library/files/${model.checksum}/download">Download</a>
+                <button class="btn btn-danger" data-act="delete">Delete</button>
+              </div>
             </div>
           </div>
+          <section class="model-detail-info">${info}${err}</section>
           <section class="model-detail-printfiles"><h3>Print files</h3><div id="mdPrintfiles"></div></section>
           <section class="model-detail-slice"><h3>Slice</h3><div id="mdSlice"></div></section>`;
     }

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.41.2")
+APP_VERSION = get_version(fallback="2.41.3")
 
 
 # Prometheus metrics - initialized once

--- a/src/services/slicing_queue.py
+++ b/src/services/slicing_queue.py
@@ -362,10 +362,20 @@ class SlicingQueue(BaseService):
                 raise Exception("Library service not available")
             
             library_file = await self.library_service.get_file_by_checksum(job.file_checksum)
-            if not library_file or not library_file.get("file_path"):
+            if not library_file:
                 raise Exception("Library file not found")
-            
-            input_file = Path(library_file["file_path"])
+
+            # Library records store a relative `library_path` (under the library root).
+            # `file_path` is only present for some sources, so resolve robustly:
+            # prefer an explicit file_path, else join library_path with the library root.
+            rel = library_file.get("file_path") or library_file.get("library_path")
+            if not rel:
+                raise Exception("Library file not found")
+            input_file = Path(rel)
+            if not input_file.is_absolute():
+                lib_root = getattr(self.library_service, "library_path", None)
+                if lib_root:
+                    input_file = Path(lib_root) / rel
             if not input_file.exists():
                 raise Exception(f"Input file not found: {input_file}")
             


### PR DESCRIPTION
Fixes slicing 'Library file not found' (records store relative library_path, not file_path) and restores the Delete/Download/metadata that the model-centric view dropped in 2.41.0. JS syntax-checked; slicing_queue parses.