### PR TITLE
feat: debug System & Libraries panel (v2.41.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.4] - 2026-06-29
+
+### Added
+- **Debug page: System & Libraries panel** — `GET /api/v1/debug/system-info` reports the app/Python versions, platform, deployment mode, slicer URL, whether preview rendering is available, and the availability + version (or import error) of each optional library (matplotlib, trimesh, numpy-stl, scipy, networkx, Pillow, packaging, build123d). Makes "why is there no STL thumbnail / why is feature X off" diagnosable at a glance. Surfaced on `/debug.html`.
+
 ## [2.41.3] - 2026-06-29
 
 ### Fixed

--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -121,6 +121,24 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- System & Libraries -->
+                <div class="debug-card">
+                    <div class="card-header">
+                        <h3>
+                            <span class="card-icon">🧩</span>
+                            System &amp; Bibliotheken
+                        </h3>
+                        <div class="card-controls">
+                            <button class="btn btn-sm" onclick="loadSystemInfo()">Aktualisieren</button>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div id="systemInfo" class="system-info">
+                            <div class="loading-spinner">Lade System-Info…</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </main>
@@ -142,6 +160,40 @@
     <script src="js/unified-log-viewer.js"></script>
     <script src="js/debug.js"></script>
     <script src="js/debug-init.js"></script>
+    <script>
+    // System & libraries panel: app/Python versions + optional-library availability.
+    async function loadSystemInfo() {
+        const host = document.getElementById('systemInfo');
+        if (!host) return;
+        host.innerHTML = '<div class="loading-spinner">Lade System-Info…</div>';
+        const badge = (ok) => ok === true ? '<span style="color:#16a34a">●</span>'
+            : ok === false ? '<span style="color:#dc2626">●</span>'
+            : '<span style="color:#9ca3af">●</span>';
+        try {
+            const base = (window.CONFIG && CONFIG.API_BASE_URL) || '/api/v1';
+            const d = await (await fetch(`${base}/debug/system-info`)).json();
+            const libRows = Object.entries(d.libraries || {}).map(([name, v]) =>
+                `<tr><td>${badge(v.available)} ${name}</td><td>${v.version || ''}</td>`
+                + `<td style="color:#dc2626">${v.available ? '' : (v.error || '')}</td></tr>`).join('');
+            host.innerHTML = `
+                <div class="system-info-meta" style="display:flex;flex-wrap:wrap;gap:8px 24px;margin-bottom:10px">
+                  <div><b>App</b> ${d.app_version}</div>
+                  <div><b>Python</b> ${d.python_version}</div>
+                  <div><b>Platform</b> ${d.platform} (${d.machine})</div>
+                  <div><b>Mode</b> ${d.deployment_mode}</div>
+                  <div><b>Preview rendering</b> ${badge(d.preview_rendering_available)} ${d.preview_rendering_available}</div>
+                  <div><b>Slicer URL</b> ${d.slicer_service_url || '—'}</div>
+                </div>
+                <table class="system-info-table" style="width:100%;border-collapse:collapse">
+                  <thead><tr><th style="text-align:left">Library</th><th style="text-align:left">Version</th><th style="text-align:left">Error</th></tr></thead>
+                  <tbody>${libRows}</tbody>
+                </table>`;
+        } catch (e) {
+            host.innerHTML = `<div class="error">Failed to load system info: ${e.message}</div>`;
+        }
+    }
+    document.addEventListener('DOMContentLoaded', loadSystemInfo);
+    </script>
 
     <style>
         .debug-page {

--- a/src/api/routers/debug.py
+++ b/src/api/routers/debug.py
@@ -175,3 +175,54 @@ async def get_thumbnail_processing_log(
         },
         "recent_attempts": transformed_entries
     }
+
+
+@router.get("/system-info", tags=["Debug"], summary="App version + Python/library availability")
+async def system_info():
+    """Report app/Python versions and availability of optional libraries.
+
+    Useful for diagnosing why previews/features are missing on a given deployment
+    (e.g. matplotlib not importable -> no STL preview thumbnails).
+    """
+    import sys
+    import platform
+    import importlib
+    from src.utils.version import get_version
+
+    def probe(module_name: str, version_attr: str = "__version__"):
+        try:
+            mod = importlib.import_module(module_name)
+            ver = getattr(mod, version_attr, None)
+            return {"available": True, "version": str(ver) if ver else None, "error": None}
+        except Exception as e:  # noqa: BLE001 - we want the message verbatim
+            return {"available": False, "version": None, "error": f"{type(e).__name__}: {e}"}
+
+    libraries = {
+        "matplotlib": probe("matplotlib"),       # STL/3MF preview thumbnail rendering
+        "trimesh": probe("trimesh"),             # STL geometry / dimensions
+        "numpy": probe("numpy"),
+        "numpy-stl": probe("stl"),
+        "scipy": probe("scipy"),
+        "networkx": probe("networkx"),
+        "Pillow": probe("PIL"),
+        "packaging": probe("packaging"),
+        "build123d": probe("build123d"),         # parametric generator (optional)
+    }
+
+    # Whether the preview renderer considers itself usable
+    try:
+        from src.services.preview_render_service import RENDERING_AVAILABLE
+        preview_rendering_available = bool(RENDERING_AVAILABLE)
+    except Exception as e:  # noqa: BLE001
+        preview_rendering_available = None
+
+    return {
+        "app_version": get_version(fallback="unknown"),
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "deployment_mode": __import__("os").getenv("DEPLOYMENT_MODE", "standalone"),
+        "preview_rendering_available": preview_rendering_available,
+        "slicer_service_url": __import__("os").getenv("SLICER_SERVICE_URL") or None,
+        "libraries": libraries,
+    }

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.41.3")
+APP_VERSION = get_version(fallback="2.41.4")
 
 
 # Prometheus metrics - initialized once


### PR DESCRIPTION
Adds /api/v1/debug/system-info + a panel on debug.html showing app/Python versions and optional-library availability (matplotlib/trimesh/Pillow/etc.) with import errors. Pairs with the add-on matplotlib fix (printernizer-ha#40) to make 'no STL thumbnail' diagnosable.