### PR TITLE
feat: slicing/model-detail UI overhaul (v2.41.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.5] - 2026-06-30
+
+### Changed
+- **Model detail / slicing UI overhaul.**
+  - **Print files table now shows real printer and profile *names*** instead of raw UUIDs (resolved via the printers and slicer-profiles lists).
+  - **Profile picker grouped by printer model** (optgroups) with a live detail line showing the selected profile's printer model and built-in/custom source.
+  - Reworked layout: larger preview, metadata shown as a clean grid, section headers, and the **Slice** panel promoted above the print-files list with a tidier form and clearer Slice / Slice & Print actions.
+
 ## [2.41.4] - 2026-06-29
 
 ### Added

--- a/frontend/css/library.css
+++ b/frontend/css/library.css
@@ -1203,21 +1203,37 @@
 }
 
 /* ── Model-centric detail view (Slicer Phase 3b) ────────────────────── */
-.model-detail { padding: 8px 0; }
-.model-detail-header { display: flex; align-items: center; gap: 16px; margin-bottom: 20px; }
-.model-detail-thumb { width: 96px; height: 96px; object-fit: contain; background: var(--surface-2, #f4f4f5); border-radius: 8px; }
-.model-detail-title h2 { margin: 0; }
+.model-detail { padding: 8px 0; max-width: 920px; }
+.model-detail-header { display: flex; align-items: flex-start; gap: 18px; margin-bottom: 8px; }
+.model-detail-thumb { width: 160px; height: 160px; object-fit: contain; background: var(--surface-2, #f4f4f5); border-radius: 10px; border: 1px solid var(--border, #e4e4e7); flex-shrink: 0; }
+.model-detail-title { flex: 1; min-width: 0; }
+.model-detail-title h2 { margin: 0 0 4px; word-break: break-word; }
 .model-detail-meta { color: var(--text-muted, #71717a); font-size: 0.9rem; }
-.model-detail section { margin-top: 24px; }
+.model-detail-actions { display: flex; gap: 8px; margin-top: 12px; }
+.model-detail section { margin-top: 28px; }
+.model-detail section > h3 { font-size: 1rem; margin: 0 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--border, #e4e4e7); }
 .model-detail .empty { color: var(--text-muted, #71717a); font-style: italic; }
+.model-detail-info { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px 20px; margin-top: 12px; }
+.md-info-row { display: flex; justify-content: space-between; gap: 12px; font-size: 0.85rem; padding: 4px 0; border-bottom: 1px dashed var(--border, #e4e4e7); }
+.md-info-k { color: var(--text-muted, #71717a); }
+.md-info-v { font-weight: 500; text-align: right; word-break: break-word; }
+.md-info-error { grid-column: 1 / -1; }
+.md-info-error .md-info-v { color: #b91c1c; font-weight: 400; }
 .role-badge { font-size: 0.7rem; padding: 1px 6px; border-radius: 10px; margin-left: 6px; }
 .role-badge.role-model { background: #dbeafe; color: #1e40af; }
 .role-badge.role-printfile { background: #dcfce7; color: #166534; }
 .md-table { width: 100%; border-collapse: collapse; }
-.md-table th, .md-table td { text-align: left; padding: 8px; border-bottom: 1px solid var(--border, #e4e4e7); font-size: 0.9rem; }
-.md-slice-form { display: flex; flex-wrap: wrap; gap: 12px; align-items: end; }
-.md-slice-form label { display: flex; flex-direction: column; font-size: 0.85rem; gap: 4px; }
-.md-progress { height: 8px; background: #e4e4e7; border-radius: 4px; overflow: hidden; margin-top: 10px; }
+.md-table th { text-align: left; padding: 8px; font-size: 0.78rem; text-transform: uppercase; letter-spacing: .03em; color: var(--text-muted, #71717a); border-bottom: 2px solid var(--border, #e4e4e7); }
+.md-table td { text-align: left; padding: 8px; border-bottom: 1px solid var(--border, #e4e4e7); font-size: 0.9rem; vertical-align: middle; }
+.md-table .md-printer { margin: 0 6px; }
+.md-slice-form { display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end; background: var(--surface-2, #f9fafb); border: 1px solid var(--border, #e4e4e7); border-radius: 10px; padding: 14px 16px; }
+.md-field { display: flex; flex-direction: column; font-size: 0.78rem; gap: 4px; color: var(--text-muted, #71717a); min-width: 240px; flex: 1; }
+.md-field select { font-size: 0.9rem; padding: 7px 8px; border-radius: 6px; }
+.md-slice-actions { display: flex; gap: 8px; }
+.md-profile-meta { display: flex; gap: 6px; margin-top: 10px; min-height: 22px; }
+.md-chip { font-size: 0.72rem; padding: 2px 9px; border-radius: 11px; background: #dbeafe; color: #1e40af; line-height: 1.6; }
+.md-chip-soft { background: var(--surface-2, #eef0f2); color: var(--text-muted, #71717a); }
+.md-progress { height: 8px; background: #e4e4e7; border-radius: 4px; overflow: hidden; margin-top: 12px; }
 .md-progress > div { height: 100%; background: #16a34a; width: 0; transition: width .3s; }
 .md-status { font-size: 0.85rem; color: var(--text-muted, #71717a); margin-top: 4px; }
 .btn-sm { padding: 2px 8px; font-size: 0.8rem; }

--- a/frontend/js/model-detail.js
+++ b/frontend/js/model-detail.js
@@ -9,6 +9,7 @@ class ModelDetailView {
         this.checksum = null;
         this._poll = null;
         this._printerCache = null;
+        this._profileCache = null;
         this._slicerId = null;
     }
 
@@ -114,8 +115,8 @@ class ModelDetailView {
             </div>
           </div>
           <section class="model-detail-info">${info}${err}</section>
-          <section class="model-detail-printfiles"><h3>Print files</h3><div id="mdPrintfiles"></div></section>
-          <section class="model-detail-slice"><h3>Slice</h3><div id="mdSlice"></div></section>`;
+          <section class="model-detail-slice"><h3>Slice</h3><div id="mdSlice"></div></section>
+          <section class="model-detail-printfiles"><h3>Print files</h3><div id="mdPrintfiles"></div></section>`;
     }
 
     async _printers() {
@@ -128,6 +129,30 @@ class ModelDetailView {
             this._printerCache = [];
         }
         return this._printerCache;
+    }
+
+    async _profiles() {
+        if (this._profileCache) return this._profileCache;
+        this._profileCache = [];
+        try {
+            const sl = await (await fetch(`${CONFIG.API_BASE_URL}/slicing`)).json();
+            const slicers = sl.slicers || [];
+            const slicer = slicers.find(s => s.is_available) || slicers[0];
+            if (slicer) {
+                this._slicerId = slicer.id;
+                const pf = await (await fetch(`${CONFIG.API_BASE_URL}/slicing/${slicer.id}/profiles`)).json();
+                this._profileCache = pf.profiles || [];
+            }
+        } catch (e) { /* none */ }
+        return this._profileCache;
+    }
+
+    async _nameMaps() {
+        const [printers, profiles] = await Promise.all([this._printers(), this._profiles()]);
+        const pmap = {}, fmap = {};
+        printers.forEach(x => { pmap[x.id] = x.name; });
+        profiles.forEach(x => { fmap[x.id] = x.profile_name; });
+        return { pmap, fmap };
     }
 
     async refreshPrintfiles() {
@@ -144,14 +169,17 @@ class ModelDetailView {
             return;
         }
         const printers = await this._printers();
+        const { pmap, fmap } = await this._nameMaps();
         const rows = printfiles.map(p => {
             const t = p.estimated_print_time ? `${Math.round(p.estimated_print_time / 60)} min` : '—';
             const fil = p.filament_used ? `${Number(p.filament_used).toFixed(1)} g` : '—';
+            const printerName = pmap[p.target_printer_id] || (p.target_printer_id ? 'Unknown printer' : '—');
+            const profileName = fmap[p.profile_id] || p.profile_name || '—';
             const pr = printers.length
                 ? `<select class="md-printer">${printers.map(x => `<option value="${x.id}">${x.name}</option>`).join('')}</select>`
                 : '';
             return `<tr data-cs="${p.checksum}">
-              <td>${p.target_printer_id || '—'}</td><td>${p.profile_id || '—'}</td>
+              <td>${printerName}</td><td>${profileName}</td>
               <td>${t}</td><td>${fil}</td>
               <td><button class="btn btn-sm" data-dl="${p.checksum}">Download</button>
                   ${pr} <button class="btn btn-sm" data-print="${p.checksum}">Print</button></td></tr>`;
@@ -179,30 +207,47 @@ class ModelDetailView {
     async renderSlicePanel() {
         const host = document.getElementById('mdSlice');
         if (!host) return;
-        let slicer = null, profiles = [];
-        try {
-            const sl = await (await fetch(`${CONFIG.API_BASE_URL}/slicing`)).json();
-            const slicers = sl.slicers || [];
-            slicer = slicers.find(s => s.is_available) || slicers[0];
-            if (slicer) {
-                const pf = await (await fetch(`${CONFIG.API_BASE_URL}/slicing/${slicer.id}/profiles`)).json();
-                profiles = pf.profiles || [];
-            }
-        } catch (e) { /* none */ }
-        if (!slicer || !profiles.length) {
-            host.innerHTML = '<div class="empty">No slicer/profile available. Add one in slicer settings.</div>';
+        const profiles = await this._profiles();
+        if (!this._slicerId || !profiles.length) {
+            host.innerHTML = '<div class="empty">No slicer or profile available yet. Start the slicer add-on and configure its URL.</div>';
             return;
         }
-        this._slicerId = slicer.id;
         const printers = await this._printers();
+
+        // Group profiles by printer model so the picker reads as names, not IDs.
+        const groups = {};
+        profiles.forEach(p => { (groups[p.printer_model || 'Other'] = groups[p.printer_model || 'Other'] || []).push(p); });
+        const profileOptions = Object.keys(groups).sort().map(model =>
+            `<optgroup label="${model}">` +
+            groups[model].map(p => `<option value="${p.id}">${p.profile_name}</option>`).join('') +
+            `</optgroup>`).join('');
+
         host.innerHTML = `
           <div class="md-slice-form">
-            <label>Profile <select id="mdProfile">${profiles.map(p => `<option value="${p.id}">${p.profile_name}</option>`).join('')}</select></label>
-            <label>Printer <select id="mdSlicePrinter"><option value="">— none —</option>${printers.map(x => `<option value="${x.id}">${x.name}</option>`).join('')}</select></label>
-            <button class="btn btn-primary" id="mdSliceBtn">Slice</button>
-            <button class="btn" id="mdSlicePrintBtn">Slice &amp; Print</button>
+            <label class="md-field">Profile
+              <select id="mdProfile">${profileOptions}</select>
+            </label>
+            <label class="md-field">Target printer
+              <select id="mdSlicePrinter"><option value="">— choose when printing —</option>${printers.map(x => `<option value="${x.id}">${x.name}</option>`).join('')}</select>
+            </label>
+            <div class="md-slice-actions">
+              <button class="btn btn-primary" id="mdSliceBtn">Slice</button>
+              <button class="btn btn-secondary" id="mdSlicePrintBtn">Slice &amp; Print</button>
+            </div>
           </div>
+          <div id="mdProfileMeta" class="md-profile-meta"></div>
           <div id="mdSliceStatus"></div>`;
+
+        const sel = host.querySelector('#mdProfile');
+        const meta = host.querySelector('#mdProfileMeta');
+        const updateMeta = () => {
+            const p = profiles.find(x => x.id === sel.value);
+            if (!p) { meta.textContent = ''; return; }
+            const src = p.is_builtin ? 'built-in' : (p.source || 'custom');
+            meta.innerHTML = `<span class="md-chip">${p.printer_model || 'Generic'}</span><span class="md-chip md-chip-soft">${src}</span>`;
+        };
+        sel.addEventListener('change', updateMeta);
+        updateMeta();
         host.querySelector('#mdSliceBtn').addEventListener('click', () => this._slice(false));
         host.querySelector('#mdSlicePrintBtn').addEventListener('click', () => this._slice(true));
     }

--- a/src/main.py
+++ b/src/main.py
@@ -102,7 +102,7 @@ from src.constants import (
 
 # Application version - Automatically extracted from git tags
 # Fallback version used when git is unavailable
-APP_VERSION = get_version(fallback="2.41.4")
+APP_VERSION = get_version(fallback="2.41.5")
 
 
 # Prometheus metrics - initialized once


### PR DESCRIPTION
Addresses the 'I see IDs' issue (print files now show printer/profile names), groups profiles by printer with a detail line, and reworks the model-detail layout (bigger preview, metadata grid, Slice promoted). JS + CSS validated.