### PR TITLE
chore(deps): Upgrade fastapi 0.138.2 + starlette 1.3.1 (fixes 6 CVEs, #346)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@
 # Requirements for Milestone 1.2: Printer API Integration
 
 # Core Framework
-fastapi==0.128.0
+fastapi==0.138.2
+# starlette pinned >=1.3.1 to remediate CVE-2026-48817/48818 and PYSEC-2026-161/248/249
+# (requires fastapi>=0.133.0, which lifts the previous starlette<0.51 cap)
+starlette==1.3.1
 uvicorn[standard]==0.40.0
 pydantic>=2.9.0
 pydantic-settings>=2.6.0


### PR DESCRIPTION
## Summary
Remediates the **6 starlette vulnerabilities** flagged by the weekly Dependency Security Scan (issue #346).

The scan found 9 vulns in 2 packages:
- **python-multipart** (3 CVEs) — already fixed by #356 (bump to 0.0.31).
- **starlette 0.50.0** (6 CVEs) — fixed here.

`starlette` was pulled transitively by `fastapi==0.128.0`, which caps `starlette<0.51`. The CVE fixes require **starlette>=1.3.1**, and `fastapi>=0.133.0` lifts that cap — so this bumps FastAPI to the latest **0.138.2** and pins **starlette==1.3.1** explicitly to document the remediation.

### CVEs resolved
CVE-2026-48817, CVE-2026-48818, PYSEC-2026-161, PYSEC-2026-248, PYSEC-2026-249

## Verification
- `pip check`: no dependency conflicts.
- Ran `tests/api` + `tests/backend` on **both** the old and new dependency stacks: **identical** result (`8 failed, 296 passed, 56 skipped`) — the 8 failures are pre-existing on master and unrelated to this bump. **No new regressions.**
- Only direct starlette imports in the codebase are `BaseHTTPMiddleware` and `starlette.responses.JSONResponse` (in `src/utils/middleware.py`), both unchanged across starlette 1.x.

## Notes
- After merge, the next weekly scan should drop from **9 → 0** vulnerable dependencies, allowing #346 to be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)