### PR TITLE
fix: backfill job start_time when printer doesn't report it yet

### DIFF
--- a/src/services/printer_monitoring_service.py
+++ b/src/services/printer_monitoring_service.py
@@ -907,8 +907,11 @@ class PrinterMonitoringService:
             # Discovery time (when we first saw it)
             'created_at': discovery_time.isoformat(),
 
-            # Actual start time from printer (if available)
-            'start_time': status.print_start_time.isoformat() if status.print_start_time else None,
+            # Actual start time from printer if it reports elapsed print time;
+            # otherwise fall back to discovery_time so the job never ends up with
+            # a permanently null start_time (auto-created jobs are never
+            # revisited to backfill this once the printer starts reporting it).
+            'start_time': (status.print_start_time or discovery_time).isoformat(),
 
             # Metadata (as dict - job_service will serialize to JSON for database)
             'customer_info': {

--- a/tests/services/test_auto_job_creation.py
+++ b/tests/services/test_auto_job_creation.py
@@ -458,6 +458,44 @@ class TestAutoCreateJobLogic:
         assert job_data['status'] == 'running'
 
     @pytest.mark.asyncio
+    async def test_auto_create_job_without_start_time_falls_back_to_discovery_time(self, monitoring_service):
+        """Should fall back to discovery_time when printer doesn't report elapsed print time yet.
+
+        Regression test: jobs auto-created before the printer reports elapsed
+        print time (e.g. Bambu MQTT `mc_print_time` still 0 on the very first
+        status update) used to get `start_time: None` permanently, since
+        auto-creation is never revisited to backfill it later. This left the
+        job showing "not started" in the UI forever despite actively printing.
+        """
+        status = PrinterStatusUpdate(
+            printer_id="bambu_001",
+            status=PrinterStatus.PRINTING,
+            current_job="model.3mf",
+            progress=1,
+            print_start_time=None,
+            timestamp=datetime.now()
+        )
+
+        # Mock dependencies
+        monitoring_service.database.list_jobs = AsyncMock(return_value=[])
+        monitoring_service.job_service.create_job = AsyncMock(return_value={'id': 'job_123'})
+
+        mock_printer = Mock()
+        mock_printer.__class__.__name__ = "BambuLabPrinter"
+        monitoring_service.connection_service.printer_instances = {"bambu_001": mock_printer}
+
+        before = datetime.now()
+        await monitoring_service._auto_create_job_if_needed(status)
+        after = datetime.now()
+
+        call_args = monitoring_service.job_service.create_job.call_args
+        job_data = call_args[0][0]
+
+        assert job_data['start_time'] is not None
+        recorded_start_time = datetime.fromisoformat(job_data['start_time'])
+        assert before <= recorded_start_time <= after
+
+    @pytest.mark.asyncio
     async def test_auto_create_job_startup_flag(self, monitoring_service):
         """Should set startup flag when is_startup=True."""
         status = PrinterStatusUpdate(


### PR DESCRIPTION
## Summary
- Auto-created jobs could end up with a permanently null `start_time` when the printer's MQTT/API data didn't yet report elapsed print time at the exact moment the print was first discovered (e.g. Bambu `mc_print_time` still `0`). Since auto-created jobs are never revisited to backfill `start_time`, this left the job showing "Nicht gestartet" in the dashboard forever, despite actively printing.
- Falls back to `discovery_time` (when Printernizer first saw the print) whenever the printer doesn't report `print_start_time`, so `start_time` is always populated.

## Test plan
- [x] Added regression test `test_auto_create_job_without_start_time_falls_back_to_discovery_time` — confirmed it fails without the fix and passes with it
- [x] `pytest tests/services/test_auto_job_creation.py tests/services/test_printer_monitoring_service.py tests/integration/test_auto_job_integration.py` — 93 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)