### PR TITLE
chore: Auto-close resolved security alerts + refresh MASTERPLAN

### DIFF
--- a/.github/workflows/dependency-security-scan.yml
+++ b/.github/workflows/dependency-security-scan.yml
@@ -185,6 +185,47 @@ jobs:
               });
             }
 
+      - name: Close resolved vulnerability issue
+        if: steps.check-vulnerabilities.outputs.has_vulnerabilities == 'false' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // A clean scan means any previously opened alert is resolved.
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,dependencies'
+            });
+
+            const existingIssue = issues.data.find(issue =>
+              issue.title.includes('Security Alert: Vulnerable Dependencies')
+            );
+
+            if (existingIssue) {
+              let body = `## ✅ Vulnerabilities Resolved\n\n`;
+              body += `The latest weekly security scan found **no known vulnerabilities** `;
+              body += `in \`requirements.txt\`. Closing this alert automatically.\n\n`;
+              body += `See the [workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId}) for details.\n\n`;
+              body += `---\n`;
+              body += `*This issue was automatically closed by the dependency security scan workflow.*`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: body
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }
+
   # Check for outdated dependencies
   outdated-check:
     name: Check Outdated Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Watcher file IDs changed on every restart.** IDs were derived from Python's salted `hash()`; they are now a deterministic digest of the file path.
 
 ### Added
+- **Watch folders (Phase 7b): per-folder processing rules** (migration 038). Each watch folder can now be configured (Files page → watch folder card, or `PATCH /api/v1/files/watch-folders/update`) with:
+  - **Auto-tagging** — ingested files are tagged with their first-level subfolder name (`vases/spiral.stl` → tag `vases`), feeding the existing Library tag filter.
+  - **Business/private classification** — ingested files are tagged `business` or `private`, so watch-folder files finally participate in the business-vs-private distinction.
+  - **Default printer / slicer profile** — stored per folder now, consumed by the auto-slice workflows coming in Phase 7c.
+  - The watch-folder cards on the Files page also show per-folder file count, last scan time, an invalid-folder badge, and a per-folder **Rescan** button.
 - **Watch folders (Phase 7a foundation):**
   - `.bgcode` files are now picked up from watch folders.
   - `POST /api/v1/files/watch-folders/rescan?folder_path=…` — rescan a single watch folder on demand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Printernizer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Real-time watch-folder monitoring never worked.** Watchdog delivers file events on its own observer thread, but the handlers called `asyncio.create_task()` there — where no event loop runs — so every created/modified/deleted/moved event raised `RuntimeError` and was lost. Files dropped into a watch folder were only picked up at the next application restart's initial scan. Events are now bridged to the main loop via `asyncio.run_coroutine_threadsafe()`.
+- **Watch-folder files could be ingested mid-copy.** A file still being copied into a watch folder was ingested as soon as the first event fired, storing a truncated copy with a wrong checksum in the library. Ingest now waits until the file's size/mtime are stable, and an in-flight guard prevents duplicate processing of the same path during event bursts.
+- **Deleting or moving a watched original left stale library sources.** The library keeps its copy (by design), but the watch-folder source entry now gets removed on delete, swapped on cross-folder moves, and refreshed when a file's content changes (new `LibraryService.remove_file_source()`).
+- **Watcher file IDs changed on every restart.** IDs were derived from Python's salted `hash()`; they are now a deterministic digest of the file path.
+
+### Added
+- **Watch folders (Phase 7a foundation):**
+  - `.bgcode` files are now picked up from watch folders.
+  - `POST /api/v1/files/watch-folders/rescan?folder_path=…` — rescan a single watch folder on demand.
+  - Periodic automatic rescan (every 5 minutes) when the watchdog observer is unavailable (fallback mode was previously blind between restarts).
+  - Per-folder `file_count` / `last_scan_at` statistics are now actually maintained in the `watch_folders` table; watch status reports whether real-time monitoring is active (`realtime_monitoring`).
+  - Watcher events now include the file's library `checksum`, groundwork for per-folder processing rules (Phase 7b).
+
 ## [2.41.7] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Watcher file IDs changed on every restart.** IDs were derived from Python's salted `hash()`; they are now a deterministic digest of the file path.
 
 ### Added
+- **Watch folders (Phase 7c): auto-slice workflow** (migration 039). A watch folder can be set to **auto-slice** — when a *new* model file (STL/OBJ/STEP or an unsliced 3MF) lands in it, it is automatically queued for slicing using the folder's default slicer profile, and the resulting gcode is registered in the library linked to its source model (via the existing Phase 3a relation).
+  - **Safety: auto-slice never starts a print.** The queued job always has `auto_upload=False` and `auto_start=False` — watch-folder automation prepares gcode and notifies; sending to a printer and starting a print stay manual actions.
+  - Auto-slice only fires the first time content enters the library, so rescans and duplicate copies never re-queue slicing jobs; gcode/already-sliced files are skipped.
+  - **New notification events `slicing_completed` / `slicing_failed`** (subscribable per channel like the existing job/printer events), so you get a Discord/Slack/ntfy ping when an auto-slice (or any slice) finishes or fails. Slicing completion/failure events now carry the filename, output file, profile and target printer.
+  - Watch-folder cards gain an **Auto-slice** toggle plus **default profile** and **default printer** pickers.
 - **Watch folders (Phase 7b): per-folder processing rules** (migration 038). Each watch folder can now be configured (Files page → watch folder card, or `PATCH /api/v1/files/watch-folders/update`) with:
   - **Auto-tagging** — ingested files are tagged with their first-level subfolder name (`vases/spiral.stl` → tag `vases`), feeding the existing Library tag filter.
   - **Business/private classification** — ingested files are tagged `business` or `private`, so watch-folder files finally participate in the business-vs-private distinction.

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -1,7 +1,7 @@
 # Printernizer Development Masterplan
 
-**Last Updated**: 2026-01-09
-**Current Version**: v2.26.0
+**Last Updated**: 2026-07-05
+**Current Version**: v2.41.7
 **E2E Test Suite**: v2.24.2 (~90% passing, debug tests excluded)
 **Status**: Production Ready
 
@@ -14,18 +14,16 @@
 | Core Features | Production Ready | 99% |
 | Printer Support | Bambu + Prusa + OctoPrint | 100% |
 | Test Coverage | Excellent | ~90% |
-| Sprint 1 (P1 Tasks) | Complete | 100% |
-| Sprint 2 Phase 1 (Service Tests) | Complete | 100% |
-| Sprint 2 Phase 2 (Feature Tests) | Complete | 100% |
-| Sprint 2 Phase 3 (Printer Tests) | Complete | 100% |
-| Sprint 3 (Frontend Polish) | Complete | 100% |
-| Sprint 4 (Tags & Printer Modal) | Complete | 100% |
-| Slicer Integration (v2.14.0) | Complete | 100% |
-| Post-Sprint Patches (v2.15.1-2.15.8) | Complete | 100% |
+| Sprints 1-4 (API, Tests, Frontend, Tags) | Complete | 100% |
 | Unified Log Viewer (v2.18.0) | Complete | 100% |
 | 3D File Preview (v2.19.0) | Complete | 100% |
+| Multi-Theme System (v2.28.0) | Complete | 100% |
+| Tools & Helpers Page (v2.29.0) | Complete | 100% |
+| Orders Tracking (v2.30.0) | Complete | 100% |
+| Model Generator (v2.32.0-2.37.0, browser/JSCAD) | Complete | 100% |
+| Slicer Integration Epic (Phase 1-3b, v2.38.0-2.41.x) | Complete | 100% |
+| Usage Statistics (Phase 3, v2.27.0) | Complete | 100% |
 | E2E Test Suite (v2.24.2) | **Priority 2** | ~90% |
-| Usage Statistics | Phase 2 Complete | 66% |
 | Code Review (2026-01-07) | Complete | 100% |
 
 ---
@@ -84,6 +82,23 @@
   - Delete printer tests: 2/2 ✅
   - Test connection tests: 2/2 ✅
 
+### Major Feature Epics (v2.27.0 - v2.41.7) ✅
+
+- [x] **Slicer Integration Epic** (v2.38.0-2.41.x) - Full STL→gcode→print pipeline
+  - **Phase 1** (v2.38.0): Standalone OrcaSlicer microservice (`slicer-service/`), pluggable backends (`RemoteHTTPBackend`/`LocalProcessBackend`), Docker + HA add-on wiring
+  - **Phase 2** (v2.39.0): Curated built-in profiles (Bambu A1, Prusa CORE One) + profile upload API
+  - **Phase 3a** (v2.40.0): Library model→printfile relation (`role`/`parent_checksum`), slice outputs registered in library
+  - **Phase 3b** (v2.41.0): Model-centric detail view with Slice / Slice & Print actions
+  - **Patches** (v2.41.1-2.41.7): path resolution, slicer detection on HA, model-detail actions, UI overhaul, dashboard fixes
+- [x] **Model Generator Epic** (v2.32.0-2.37.0) - Parametric model generation
+  - Now runs **in-browser via JSCAD** (v2.34.0) so it works on all architectures incl. Raspberry Pi/HA (previously server-side OpenSCAD then build123d, both ARM-incompatible)
+  - Templates: box, vase, Text/Nameplate/Keychain, QR Tag, Gridfinity Bin/Baseplate, Bracket, Standoff, SVG→Extrude, Lithophane, Custom JSCAD (v2.35.0-2.37.0)
+- [x] **Orders Tracking** (v2.30.0) - Full order management on top of the job system
+  - Customer database, order lifecycle (`new→planned→printed→delivered`), configurable sources, payment status, order analytics, HA path fixes (v2.30.2-2.30.7)
+- [x] **Usage Statistics Phase 3** (v2.27.0) - Analytics dashboard, 15+ stats endpoints, SMTP email reports, anomaly detection
+- [x] **Multi-Theme System** (v2.28.0) - 7 selectable UI themes with picker in Settings
+- [x] **Tools & Helpers Page** (v2.29.0) - Curated external 3D-printing links + Gridfinity tools
+
 ### Recent Features (v2.10.0 - v2.26.0) ✅
 
 - [x] **v2.26.0** - Multi-channel notifications (Discord, Slack, ntfy.sh) with per-event subscriptions
@@ -121,20 +136,33 @@
 - [x] **Business Features** - VAT, analytics, German compliance
 - [x] **Auto-Job Creation** - Detect prints automatically
 - [x] **Setup Wizard** - Guided first-run configuration
-- [x] **Slicer Integration** - Auto-detect Bambu Studio, Orca, Prusa Slicer (v2.14.0)
+- [x] **Slicer Integration** - Auto-detect local slicers (v2.14.0) + standalone OrcaSlicer microservice with full slice→print pipeline (v2.38.0-2.41.x)
 - [x] **Custom File Tags** - Tag management system with filtering (v2.15.0)
+- [x] **Orders Tracking** - Customer/order management on top of jobs (v2.30.0)
+- [x] **Model Generator** - Browser-based parametric model generation via JSCAD (v2.34.0+)
+- [x] **Multi-Theme System** - 7 selectable UI themes (v2.28.0)
 
-### Usage Statistics (v2.7.0) ✅
+### Usage Statistics (v2.7.0 - v2.27.0) ✅
 
 - [x] **Phase 1**: Local collection, UI, opt-in/opt-out
 - [x] **Phase 2**: Aggregation service, HTTP submission, scheduler
-- [ ] **Phase 3**: Analytics dashboard (planned)
+- [x] **Phase 3** (v2.27.0): Analytics dashboard, 15+ stats endpoints, SMTP email reports, anomaly detection
 
 ---
 
 ## In Progress
 
-> No tasks currently in progress. Ready for next sprint.
+> No tasks currently in progress. The Slicer Integration epic (Phase 1-3b) shipped in v2.38.0-2.41.0, followed by the v2.41.x stabilization series (dashboard fixes, slicer detection, model-detail actions). Master is on v2.41.7 with CI green and no open PRs.
+
+### Next Candidates
+
+Realistic next epics from the roadmap below, roughly in order of continuity with recent work:
+
+- [ ] **Watch Folders Enhancement** (Phase 7) - auto-slice/auto-upload workflows, auto-tagging, duplicate detection
+- [ ] **Advanced Home Assistant Integration** (Phase 6) - MQTT discovery, sensor entities, automation triggers
+- [ ] **Print Queue System** - manual reordering, priority levels, queue dashboard
+- [ ] **Expanded Printer Support** (Phase 10) - Klipper via Moonraker API
+- [ ] **Printer Error Message Handling** - capture/display error codes with suggested fixes
 
 ### Sprint 4 - Tags & Printer Details ✅ COMPLETE (2026-01-05)
 
@@ -477,12 +505,12 @@ The debug page (`/debug.html`) tests consistently fail because:
 - [x] **OctoPrint** (v2.25.0) - SockJS WebSocket integration
 - **Effort**: 10-15 hours per manufacturer
 
-### Usage Statistics Phase 3
-- [ ] Analytics dashboard
-- [ ] Key metrics visualization
-- [ ] Trend analysis
-- [ ] Anomaly detection
-- **Effort**: 2 weeks
+### Usage Statistics Phase 3 ✅ COMPLETE (v2.27.0)
+- [x] Analytics dashboard
+- [x] Key metrics visualization
+- [x] Trend analysis
+- [x] Anomaly detection
+- [x] SMTP email reports (weekly/monthly)
 
 ---
 
@@ -784,9 +812,9 @@ python3 -m pytest --cov=src tests/
 
 ### Branch Strategy
 
-- **master**: Production releases
-- **development**: Integration testing
-- Feature branches → development → master
+- **master**: All development and production releases; tagged commits (`vX.Y.Z`) trigger releases
+- Feature branches → master (PR) → tag for release
+- See `.claude/rules/workflow/branching.md` for the full workflow
 
 ---
 
@@ -805,6 +833,12 @@ python3 -m pytest --cov=src tests/
 | E2E Tests | 2026-01-07 | Playwright E2E Suite | ⚠️ 94% (14 failures) |
 | OctoPrint | 2026-01-08 | OctoPrint Integration (v2.25.0) | ✅ Complete |
 | Notifications | 2026-01-09 | Multi-channel Notifications (v2.26.0) | ✅ Complete |
+| Usage Stats P3 | 2026-01-15 | Analytics dashboard, email reports (v2.27.0) | ✅ Complete |
+| Themes | 2026-01-16 | Multi-Theme System (v2.28.0) | ✅ Complete |
+| Tools Page | 2026-02-07 | Tools & Helpers page (v2.29.0) | ✅ Complete |
+| Orders | 2026-03-21 | Orders Tracking + HA fixes (v2.30.0-2.30.7) | ✅ Complete |
+| Model Generator | 2026-06-13 to 06-22 | Parametric generator, moved to browser/JSCAD (v2.32.0-2.37.0) | ✅ Complete |
+| Slicer Epic | 2026-06-25 to 07-03 | Slicer microservice + slice→print pipeline (v2.38.0-2.41.7) | ✅ Complete |
 
 ### Sprint 1 Summary
 
@@ -959,6 +993,7 @@ Created comprehensive Playwright E2E test suite covering all 10 pages using Page
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 18.0 | 2026-07-05 | Refreshed to v2.41.7: Slicer Integration epic, Model Generator, Orders Tracking, Usage Stats Phase 3, Multi-Theme, Tools page; added Next Candidates; fixed branch strategy |
 | 17.0 | 2026-01-09 | Multi-channel Notifications complete (v2.26.0) |
 | 16.0 | 2026-01-09 | OctoPrint integration complete (v2.25.0), Phase 10 progress |
 | 15.0 | 2026-01-08 | CI/CD test fixes, database schema divergence documented |

--- a/docs/MASTERPLAN.md
+++ b/docs/MASTERPLAN.md
@@ -152,14 +152,20 @@
 
 ## In Progress
 
-> No tasks currently in progress. The Slicer Integration epic (Phase 1-3b) shipped in v2.38.0-2.41.0, followed by the v2.41.x stabilization series (dashboard fixes, slicer detection, model-detail actions). Master is on v2.41.7 with CI green and no open PRs.
+> **Watch Folders Enhancement (Phase 7)** is being built on branch `claude/whats-next-waejsb` (not yet released). 7a/7b/7c complete; see below.
+
+### Watch Folders Enhancement (Phase 7) — in progress
+
+- [x] **7a — Foundation**: fixed real-time monitoring (watchdog thread → event-loop bridge), write-stability check before ingest, delete/move/modify reconciliation with the library, deterministic file IDs, `.bgcode` support, on-demand rescan endpoint, periodic fallback rescan, folder scan statistics.
+- [x] **7b — Per-folder rules** (migration 038): auto-tagging from first-level subfolder, business/private classification, default printer/profile per folder, richer settings UI (status, scan stats, rescan button).
+- [x] **7c — Auto-slice workflow** (migration 039): new model files auto-queued for slicing with the folder's default profile; **never auto-prints** (`auto_upload`/`auto_start` always false); `slicing_completed`/`slicing_failed` notification events; auto-slice toggle + printer/profile pickers in the UI.
+- [ ] **7d — External sources** (deferred/stretch): Thingiverse/Printables "save URL → library" reusing the ingest pipeline.
 
 ### Next Candidates
 
 Realistic next epics from the roadmap below, roughly in order of continuity with recent work:
 
-- [ ] **Watch Folders Enhancement** (Phase 7) - auto-slice/auto-upload workflows, auto-tagging, duplicate detection
-- [ ] **Advanced Home Assistant Integration** (Phase 6) - MQTT discovery, sensor entities, automation triggers
+- [ ] **Advanced Home Assistant Integration** (Phase 6) - MQTT discovery, sensor entities, automation triggers (can republish the Phase 7c `watch_folder.*` / `slicing_job.*` events)
 - [ ] **Print Queue System** - manual reordering, priority levels, queue dashboard
 - [ ] **Expanded Printer Support** (Phase 10) - Klipper via Moonraker API
 - [ ] **Printer Error Message Handling** - capture/display error codes with suggested fixes

--- a/docs/plans/WATCH_FOLDERS_PHASE7.md
+++ b/docs/plans/WATCH_FOLDERS_PHASE7.md
@@ -1,0 +1,129 @@
+# Watch Folders Enhancement (Phase 7)
+
+**Status**: 7a / 7b / 7c complete (branch `claude/whats-next-waejsb`, unreleased). 7d deferred.
+**Last Updated**: 2026-07-05
+
+This document records what shipped in Phase 7 and the concrete follow-up
+work that was intentionally left out, so it can be picked up later without
+re-deriving the context.
+
+---
+
+## What shipped
+
+### 7a — Foundation (bug fixes + hardening)
+
+Before this work the real-time half of watch folders never functioned.
+
+- **Thread → event-loop bridge**: watchdog delivers events on its own
+  observer thread, where the old code called `asyncio.create_task()` — no
+  running loop, so every created/modified/deleted/moved event raised
+  `RuntimeError` and was lost. Events are now scheduled onto the captured
+  main loop via `asyncio.run_coroutine_threadsafe()`.
+- **Write-stability check**: ingest waits until a file's size/mtime stop
+  changing before processing, so a file still being copied is no longer
+  stored truncated with a wrong checksum. An in-flight guard suppresses
+  duplicate processing during event bursts.
+- **Library reconciliation**: delete removes the watch-folder source from
+  the library record, cross-folder moves swap the source, content changes
+  refresh it (`LibraryService.remove_file_source`).
+- **Deterministic file IDs** (sha1 of path) instead of Python's salted
+  `hash()`, which changed every restart.
+- `.bgcode` support, `POST /api/v1/files/watch-folders/rescan`, periodic
+  fallback rescan when the observer can't start, and `file_count` /
+  `last_scan_at` statistics maintained in the `watch_folders` table.
+
+### 7b — Per-folder processing rules (migration 038)
+
+- **Auto-tagging** from first-level subfolder (`vases/spiral.stl` → tag
+  `vases`), via `LibraryService.assign_tag_by_name()`.
+- **Business/private classification** tag on ingest.
+- **Default printer / profile** stored per folder (consumed by 7c).
+- Settings UI: per-folder cards with status, scan stats, rescan button,
+  auto-tag toggle, classification select.
+
+### 7c — Auto-slice workflow (migration 039)
+
+- New model files ingested into an `auto_slice` folder with a default
+  profile are automatically queued for slicing; the gcode registers in
+  the library linked to its source model (Phase 3a relation).
+- **Safety invariant — never auto-prints.** The queued job always has
+  `auto_upload=False` and `auto_start=False`. There is a test asserting
+  this (`test_auto_slice_queues_new_model_and_never_prints`); keep it.
+- Fires only on the first ingest of new content (not rescans/duplicates);
+  gcode / already-sliced files are skipped.
+- New notification events `slicing_completed` / `slicing_failed`
+  (subscribable per channel); slicing events enriched with filename,
+  output file, profile, target printer.
+- UI: auto-slice toggle + default profile/printer pickers on folder cards.
+
+---
+
+## Follow-up work
+
+### 7d — External sources (deferred / stretch)
+
+Goal: "save a Thingiverse/Printables URL → library", reusing the ingest
+pipeline 7a–7c built.
+
+- Reuse `url_parser_service` (already exists for the Ideas/trending
+  features) for URL classification and metadata.
+- Add a download step that fetches the model bytes to a temp path, then
+  routes them through the same `LibraryService.add_file_to_library()` +
+  `_apply_folder_rules()` path so tagging/classification/auto-slice all
+  apply identically to a dropped file.
+- Licensing metadata: capture and store the source license where the
+  platform exposes it (Printables/Thingiverse APIs do). This is the main
+  reason it was split out — it's a different problem shape (HTTP auth,
+  rate limits, licensing) than local folder watching.
+- Likely surfaces as a "Import from URL" action on the Library page, not
+  a watch-folder concept — revisit whether it belongs under Phase 7 at
+  all or as its own small feature.
+
+### Release checklist for Phase 7 (when ready)
+
+Nothing here is tagged or version-bumped yet — the branch carries the
+work under `CHANGELOG.md`'s `[Unreleased]` section. To release:
+
+1. Decide the version (minor bump — new feature, no breaking changes).
+2. Move the `[Unreleased]` block in `CHANGELOG.md` under the new version
+   heading with the date.
+3. Update the fallback version in `src/main.py` (`get_version(fallback=…)`).
+4. Commit (`chore: Bump version to X.Y.Z`), tag `vX.Y.Z`, push tags.
+   GitHub Actions handles the GitHub release + HA-repo sync.
+
+**Migrations 038 and 039** apply cleanly on top of 031 and are guarded
+by the migration runner's duplicate-column tolerance; `WatchFolder`'s
+`from_db_row` also tolerates pre-migration rows (defaults for the new
+columns). No manual DB steps required.
+
+### Testing gaps to close later
+
+- **No integration test exercises the full watchdog path** (drop a real
+  file → observer fires → ingest → library). 7a is covered by unit tests
+  that call the handlers directly; an end-to-end test with a real
+  `Observer` would catch thread-bridge regressions the unit tests can't.
+- **No notification-service test file exists at all** (`tests/services/`
+  has none). The new `slicing_completed`/`slicing_failed` subscriptions
+  are only covered indirectly. Worth adding a focused test that emits
+  `slicing_job.completed` and asserts a dispatch.
+- **Manual UI verification pending**: the folder-card auto-slice pickers
+  were not exercised in a running browser (backend + JS syntax validated
+  only). Verify the pickers populate and persist against a live slicer.
+
+---
+
+## Next epic — Advanced Home Assistant Integration (Phase 6)
+
+Deliberately set up by 7c: the pipeline emits stable, well-named events
+through `EventService`:
+
+- `watch_folder.auto_slice_queued`
+- `slicing_job.completed` / `slicing_job.failed` (enriched payloads)
+- plus the existing `file_watcher` and job/printer events.
+
+The HA epic can largely **republish these over MQTT** (discovery +
+sensor entities + automation triggers) rather than inventing new event
+semantics — e.g. "flash a light when a hot-folder file finishes slicing"
+becomes a thin transport layer over events that already exist. Start
+there rather than retrofitting event plumbing.

--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -5718,3 +5718,41 @@ label .required {
         grid-template-columns: 1fr;
     }
 }
+
+/* Watch Folder Rules (Phase 7b) */
+.folder-scan-info {
+    margin-top: var(--spacing-1);
+    color: var(--gray-500);
+    font-size: var(--text-xs);
+}
+
+.folder-rules {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-3);
+    margin-top: var(--spacing-2);
+    font-size: var(--text-sm);
+    color: var(--gray-600);
+}
+
+.folder-rule {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-1);
+    cursor: pointer;
+}
+
+.folder-rule select {
+    padding: 2px var(--spacing-1);
+    font-size: var(--text-sm);
+    border: 1px solid var(--gray-300);
+    border-radius: var(--radius-sm);
+    background: var(--white);
+    color: var(--gray-800);
+}
+
+.status-badge.error {
+    background: var(--danger-color, #dc2626);
+    color: var(--white);
+}

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -389,8 +389,21 @@ class ApiClient {
         return this.post('files/watch-folders/reload');
     }
 
-    async updateWatchFolder(folderPath, isActive) {
-        return this.patch('files/watch-folders/update?folder_path=' + encodeURIComponent(folderPath) + '&is_active=' + isActive);
+    async updateWatchFolder(folderPath, fields) {
+        // Accepts a boolean (legacy is_active toggle) or an object of fields:
+        // { is_active, auto_tag, classification, default_printer_id, default_profile_id }
+        const params = new URLSearchParams({ folder_path: folderPath });
+        const updates = (typeof fields === 'boolean') ? { is_active: fields } : (fields || {});
+        for (const [key, value] of Object.entries(updates)) {
+            if (value !== undefined && value !== null) {
+                params.append(key, value);
+            }
+        }
+        return this.patch('files/watch-folders/update?' + params.toString());
+    }
+
+    async rescanWatchFolder(folderPath) {
+        return this.post('files/watch-folders/rescan?folder_path=' + encodeURIComponent(folderPath));
     }
 
     // Statistics Endpoints

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -406,6 +406,14 @@ class ApiClient {
         return this.post('files/watch-folders/rescan?folder_path=' + encodeURIComponent(folderPath));
     }
 
+    async getSlicers() {
+        return this.get('slicing');
+    }
+
+    async getSlicerProfiles(slicerId) {
+        return this.get('slicing/' + encodeURIComponent(slicerId) + '/profiles');
+    }
+
     // Statistics Endpoints
     async getStatisticsOverview(period = 'month') {
         return this.get(CONFIG.ENDPOINTS.STATISTICS_OVERVIEW, { period });

--- a/frontend/js/files.js
+++ b/frontend/js/files.js
@@ -1117,10 +1117,15 @@ class FileManager {
             <div class="watch-folders-grid">
                 ${watchFolders.map(folder => {
                     const folderPath = typeof folder === 'string' ? folder : folder.folder_path;
-                    const isActive = typeof folder === 'object' ? folder.is_active : true;
+                    const isObject = typeof folder === 'object';
+                    const isActive = isObject ? folder.is_active : true;
+                    const isValid = isObject ? (folder.is_valid !== false) : true;
                     const statusBadge = isActive
                         ? `<span class="status-badge active">${t('files.active')}</span>`
                         : `<span class="status-badge inactive">${t('files.inactive')}</span>`;
+                    const invalidBadge = !isValid
+                        ? `<span class="status-badge error" title="${escapeHtml(folder.validation_error || '')}">${t('files.invalidFolder')}</span>`
+                        : '';
 
                     const toggleButton = isActive
                         ? `<button class="btn btn-warning btn-sm" onclick="deactivateWatchFolder('${escapeHtml(folderPath)}')"
@@ -1131,15 +1136,57 @@ class FileManager {
                                title="${t('files.activateFolder')}">
                                <span class="btn-icon">▶️</span>
                            </button>`;
-                    
+
+                    // Scan statistics (folder objects only)
+                    let scanInfo = '';
+                    if (isObject) {
+                        const lastScan = folder.last_scan_at
+                            ? new Date(folder.last_scan_at).toLocaleString()
+                            : t('files.neverScanned');
+                        scanInfo = `
+                            <div class="folder-scan-info">
+                                <small>${t('files.fileCount')}: ${folder.file_count ?? 0} · ${t('files.lastScan')}: ${lastScan}</small>
+                            </div>
+                        `;
+                    }
+
+                    // Processing rules (folder objects only)
+                    let rulesRow = '';
+                    if (isObject) {
+                        const classification = folder.classification || '';
+                        rulesRow = `
+                            <div class="folder-rules">
+                                <label class="folder-rule" title="${t('files.autoTagHint')}">
+                                    <input type="checkbox" ${folder.auto_tag ? 'checked' : ''}
+                                           onchange="updateWatchFolderRule('${escapeHtml(folderPath)}', 'auto_tag', this.checked)">
+                                    ${t('files.autoTagLabel')}
+                                </label>
+                                <label class="folder-rule">
+                                    ${t('files.classificationLabel')}:
+                                    <select onchange="updateWatchFolderRule('${escapeHtml(folderPath)}', 'classification', this.value)">
+                                        <option value="" ${classification === '' ? 'selected' : ''}>${t('files.classificationNone')}</option>
+                                        <option value="business" ${classification === 'business' ? 'selected' : ''}>${t('files.classificationBusiness')}</option>
+                                        <option value="private" ${classification === 'private' ? 'selected' : ''}>${t('files.classificationPrivate')}</option>
+                                    </select>
+                                </label>
+                            </div>
+                        `;
+                    }
+
                     return `
                         <div class="watch-folder-item ${isActive ? 'active' : 'inactive'}">
                             <div class="folder-icon">📂</div>
                             <div class="folder-info">
                                 <div class="folder-path" title="${escapeHtml(folderPath)}">${escapeHtml(folderPath)}</div>
-                                <div class="folder-status">${statusBadge}</div>
+                                <div class="folder-status">${statusBadge}${invalidBadge}</div>
+                                ${scanInfo}
+                                ${rulesRow}
                             </div>
                             <div class="folder-actions">
+                                <button class="btn btn-secondary btn-sm" onclick="rescanWatchFolder('${escapeHtml(folderPath)}')"
+                                        title="${t('files.rescanFolder')}">
+                                    <span class="btn-icon">🔄</span>
+                                </button>
                                 ${toggleButton}
                                 <button class="btn btn-danger btn-sm" onclick="removeWatchFolder('${escapeHtml(folderPath)}')"
                                         title="${t('files.removeFolder')}">
@@ -1641,6 +1688,43 @@ async function deactivateWatchFolder(folderPath) {
         Logger.error('Failed to deactivate watch folder:', error);
         const message = error instanceof ApiError ? error.getUserMessage() : t('files.deactivateFolderError');
         showToast('error', t('common.error'), message);
+    }
+}
+
+/**
+ * Rescan a single watch folder (called from template)
+ */
+async function rescanWatchFolder(folderPath) {
+    try {
+        const response = await api.rescanWatchFolder(folderPath);
+        showToast('success', t('common.success'),
+            t('files.rescanComplete', {
+                found: response.files_found ?? 0,
+                new: response.new_files ?? 0
+            }));
+        fileManager.loadWatchFolders();
+    } catch (error) {
+        Logger.error('Failed to rescan watch folder:', error);
+        const message = error instanceof ApiError ? error.getUserMessage() : t('files.rescanError');
+        showToast('error', t('common.error'), message);
+    }
+}
+
+/**
+ * Update a watch folder processing rule (called from template)
+ */
+async function updateWatchFolderRule(folderPath, field, value) {
+    try {
+        const response = await api.updateWatchFolder(folderPath, { [field]: value });
+
+        if (response.success) {
+            showToast('success', t('common.success'), t('files.ruleUpdated'));
+        }
+    } catch (error) {
+        Logger.error('Failed to update watch folder rule:', error);
+        const message = error instanceof ApiError ? error.getUserMessage() : t('files.ruleUpdateError');
+        showToast('error', t('common.error'), message);
+        fileManager.loadWatchFolders();  // Restore actual state
     }
 }
 

--- a/frontend/js/files.js
+++ b/frontend/js/files.js
@@ -1056,9 +1056,26 @@ class FileManager {
                 api.getWatchFolderSettings(),
                 api.getWatchFolderStatus()
             ]);
-            
+
+            // Best-effort: printers + slicer profiles for the auto-slice pickers
+            let printers = [];
+            let profiles = [];
+            try {
+                const printersResp = await api.getPrinters();
+                printers = printersResp.printers || printersResp || [];
+            } catch (e) { /* pickers render empty */ }
+            try {
+                const slicersResp = await api.getSlicers();
+                const slicers = slicersResp.slicers || [];
+                const slicer = slicers.find(s => s.is_available) || slicers[0];
+                if (slicer) {
+                    const profilesResp = await api.getSlicerProfiles(slicer.id);
+                    profiles = profilesResp.profiles || [];
+                }
+            } catch (e) { /* pickers render empty */ }
+
             // Render watch folders display
-            container.innerHTML = this.renderWatchFolders(settings, status);
+            container.innerHTML = this.renderWatchFolders(settings, status, printers, profiles);
             
         } catch (error) {
             Logger.error('Failed to load watch folders:', error);
@@ -1072,7 +1089,7 @@ class FileManager {
     /**
      * Render watch folders display
      */
-    renderWatchFolders(settings, status) {
+    renderWatchFolders(settings, status, printers = [], slicerProfiles = []) {
         const watchFolders = settings.watch_folders || [];
         const isEnabled = settings.enabled;
         const isRecursive = settings.recursive;
@@ -1154,6 +1171,12 @@ class FileManager {
                     let rulesRow = '';
                     if (isObject) {
                         const classification = folder.classification || '';
+                        const printerOptions = printers.map(p =>
+                            `<option value="${escapeHtml(p.id)}" ${folder.default_printer_id === p.id ? 'selected' : ''}>${escapeHtml(p.name || p.id)}</option>`
+                        ).join('');
+                        const profileOptions = slicerProfiles.map(p =>
+                            `<option value="${escapeHtml(p.id)}" ${folder.default_profile_id === p.id ? 'selected' : ''}>${escapeHtml(p.profile_name || p.name || p.id)}</option>`
+                        ).join('');
                         rulesRow = `
                             <div class="folder-rules">
                                 <label class="folder-rule" title="${t('files.autoTagHint')}">
@@ -1167,6 +1190,25 @@ class FileManager {
                                         <option value="" ${classification === '' ? 'selected' : ''}>${t('files.classificationNone')}</option>
                                         <option value="business" ${classification === 'business' ? 'selected' : ''}>${t('files.classificationBusiness')}</option>
                                         <option value="private" ${classification === 'private' ? 'selected' : ''}>${t('files.classificationPrivate')}</option>
+                                    </select>
+                                </label>
+                                <label class="folder-rule" title="${t('files.autoSliceHint')}">
+                                    <input type="checkbox" ${folder.auto_slice ? 'checked' : ''}
+                                           onchange="updateWatchFolderRule('${escapeHtml(folderPath)}', 'auto_slice', this.checked)">
+                                    ${t('files.autoSliceLabel')}
+                                </label>
+                                <label class="folder-rule">
+                                    ${t('files.defaultProfileLabel')}:
+                                    <select onchange="updateWatchFolderRule('${escapeHtml(folderPath)}', 'default_profile_id', this.value)">
+                                        <option value="" ${!folder.default_profile_id ? 'selected' : ''}>${t('files.classificationNone')}</option>
+                                        ${profileOptions}
+                                    </select>
+                                </label>
+                                <label class="folder-rule">
+                                    ${t('files.defaultPrinterLabel')}:
+                                    <select onchange="updateWatchFolderRule('${escapeHtml(folderPath)}', 'default_printer_id', this.value)">
+                                        <option value="" ${!folder.default_printer_id ? 'selected' : ''}>${t('files.classificationNone')}</option>
+                                        ${printerOptions}
                                     </select>
                                 </label>
                             </div>

--- a/frontend/locales/de.json
+++ b/frontend/locales/de.json
@@ -595,7 +595,11 @@
     "lastScan": "Letzter Scan",
     "fileCount": "Dateien",
     "invalidFolder": "Ungültig",
-    "neverScanned": "nie"
+    "neverScanned": "nie",
+    "autoSliceLabel": "Auto-Slice",
+    "autoSliceHint": "Neue Modelldateien automatisch mit dem Standardprofil slicen (startet nie einen Druck)",
+    "defaultProfileLabel": "Profil",
+    "defaultPrinterLabel": "Drucker"
   },
   "materials": {
     "actions": "Aktionen",

--- a/frontend/locales/de.json
+++ b/frontend/locales/de.json
@@ -580,7 +580,22 @@
     "loadingWatchFolders": "Lade überwachte Verzeichnisse…",
     "discoveredFiles": "Entdeckte Dateien",
     "loadingDiscoveredFiles": "Lade entdeckte Dateien…",
-    "loadingFiles": "Lade Dateien…"
+    "loadingFiles": "Lade Dateien…",
+    "rescanFolder": "Ordner neu scannen",
+    "rescanComplete": "Scan abgeschlossen: {found} Dateien gefunden ({new} neu)",
+    "rescanError": "Ordner konnte nicht neu gescannt werden",
+    "autoTagLabel": "Auto-Tag",
+    "autoTagHint": "Neue Dateien mit dem Namen des ersten Unterordners taggen",
+    "classificationLabel": "Typ",
+    "classificationNone": "—",
+    "classificationBusiness": "Geschäftlich",
+    "classificationPrivate": "Privat",
+    "ruleUpdated": "Ordnerregel aktualisiert",
+    "ruleUpdateError": "Ordnerregel konnte nicht aktualisiert werden",
+    "lastScan": "Letzter Scan",
+    "fileCount": "Dateien",
+    "invalidFolder": "Ungültig",
+    "neverScanned": "nie"
   },
   "materials": {
     "actions": "Aktionen",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -595,7 +595,11 @@
     "lastScan": "Last scan",
     "fileCount": "Files",
     "invalidFolder": "Invalid",
-    "neverScanned": "never"
+    "neverScanned": "never",
+    "autoSliceLabel": "Auto-slice",
+    "autoSliceHint": "Queue new model files for slicing with the default profile (never starts a print)",
+    "defaultProfileLabel": "Profile",
+    "defaultPrinterLabel": "Printer"
   },
   "materials": {
     "actions": "Actions",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -580,7 +580,22 @@
     "loadingWatchFolders": "Loading watched directories…",
     "discoveredFiles": "Discovered files",
     "loadingDiscoveredFiles": "Loading discovered files…",
-    "loadingFiles": "Loading files…"
+    "loadingFiles": "Loading files…",
+    "rescanFolder": "Rescan folder",
+    "rescanComplete": "Rescan complete: {found} files found ({new} new)",
+    "rescanError": "Failed to rescan folder",
+    "autoTagLabel": "Auto-tag",
+    "autoTagHint": "Tag new files with their first-level subfolder name",
+    "classificationLabel": "Type",
+    "classificationNone": "—",
+    "classificationBusiness": "Business",
+    "classificationPrivate": "Private",
+    "ruleUpdated": "Folder rule updated",
+    "ruleUpdateError": "Failed to update folder rule",
+    "lastScan": "Last scan",
+    "fileCount": "Files",
+    "invalidFolder": "Invalid",
+    "neverScanned": "never"
   },
   "materials": {
     "actions": "Actions",

--- a/migrations/038_watch_folder_rules.sql
+++ b/migrations/038_watch_folder_rules.sql
@@ -1,0 +1,12 @@
+-- Migration: 038_watch_folder_rules.sql
+-- Description: Per-folder processing rules for watch folders (Phase 7b).
+--              auto_tag: derive a tag from the first-level subfolder on ingest.
+--              classification: tag ingested files as business or private.
+--              default_printer_id / default_profile_id: defaults consumed by
+--              the auto-slice workflows (Phase 7c).
+-- Date: 2026-07-05
+
+ALTER TABLE watch_folders ADD COLUMN auto_tag BOOLEAN NOT NULL DEFAULT 0;
+ALTER TABLE watch_folders ADD COLUMN classification TEXT;
+ALTER TABLE watch_folders ADD COLUMN default_printer_id TEXT;
+ALTER TABLE watch_folders ADD COLUMN default_profile_id TEXT;

--- a/migrations/039_watch_folder_auto_slice.sql
+++ b/migrations/039_watch_folder_auto_slice.sql
@@ -1,0 +1,8 @@
+-- Migration: 039_watch_folder_auto_slice.sql
+-- Description: Auto-slice workflow flag for watch folders (Phase 7c).
+--              When enabled (and a default profile is configured), newly
+--              ingested model files are queued for slicing automatically.
+--              Prints are never started automatically.
+-- Date: 2026-07-05
+
+ALTER TABLE watch_folders ADD COLUMN auto_slice BOOLEAN NOT NULL DEFAULT 0;

--- a/src/api/routers/files.py
+++ b/src/api/routers/files.py
@@ -1024,6 +1024,7 @@ async def update_watch_folder(
     folder_path: str = Query(..., description="Folder path to update"),
     is_active: Optional[bool] = Query(None, description="Whether to activate or deactivate the folder"),
     auto_tag: Optional[bool] = Query(None, description="Tag ingested files with their first-level subfolder name"),
+    auto_slice: Optional[bool] = Query(None, description="Queue new model files for slicing with the folder's default profile (never starts a print)"),
     classification: Optional[str] = Query(None, description="Tag ingested files as 'business' or 'private'; empty string clears"),
     default_printer_id: Optional[str] = Query(None, description="Default printer for folder workflows; empty string clears"),
     default_profile_id: Optional[str] = Query(None, description="Default slicer profile for folder workflows; empty string clears"),
@@ -1046,6 +1047,8 @@ async def update_watch_folder(
         updates["is_active"] = is_active
     if auto_tag is not None:
         updates["auto_tag"] = auto_tag
+    if auto_slice is not None:
+        updates["auto_slice"] = auto_slice
     if classification is not None:
         if classification not in ("", "business", "private"):
             raise PrinternizerValidationError(

--- a/src/api/routers/files.py
+++ b/src/api/routers/files.py
@@ -1022,11 +1022,15 @@ async def remove_watch_folder(
 @router.patch("/watch-folders/update")
 async def update_watch_folder(
     folder_path: str = Query(..., description="Folder path to update"),
-    is_active: bool = Query(..., description="Whether to activate or deactivate the folder"),
+    is_active: Optional[bool] = Query(None, description="Whether to activate or deactivate the folder"),
+    auto_tag: Optional[bool] = Query(None, description="Tag ingested files with their first-level subfolder name"),
+    classification: Optional[str] = Query(None, description="Tag ingested files as 'business' or 'private'; empty string clears"),
+    default_printer_id: Optional[str] = Query(None, description="Default printer for folder workflows; empty string clears"),
+    default_profile_id: Optional[str] = Query(None, description="Default slicer profile for folder workflows; empty string clears"),
     config_service: ConfigService = Depends(get_config_service),
     file_service: FileService = Depends(get_file_service)
 ):
-    """Update watch folder activation status."""
+    """Update watch folder activation status and processing rules."""
     # First get the watch folder by path to get its ID
     await config_service._ensure_env_migration()
     folder = await config_service.watch_folder_db.get_watch_folder_by_path(folder_path)
@@ -1037,10 +1041,32 @@ async def update_watch_folder(
             error="Watch folder not found"
         )
 
-    # Update the folder's active status
+    updates = {}
+    if is_active is not None:
+        updates["is_active"] = is_active
+    if auto_tag is not None:
+        updates["auto_tag"] = auto_tag
+    if classification is not None:
+        if classification not in ("", "business", "private"):
+            raise PrinternizerValidationError(
+                field="classification",
+                error="classification must be 'business', 'private' or empty"
+            )
+        updates["classification"] = classification or None
+    if default_printer_id is not None:
+        updates["default_printer_id"] = default_printer_id or None
+    if default_profile_id is not None:
+        updates["default_profile_id"] = default_profile_id or None
+
+    if not updates:
+        raise PrinternizerValidationError(
+            field="folder_path",
+            error="No fields to update"
+        )
+
     success = await config_service.watch_folder_db.update_watch_folder(
         folder.id,
-        {"is_active": is_active}
+        updates
     )
 
     if not success:
@@ -1050,15 +1076,16 @@ async def update_watch_folder(
             reason="Failed to update watch folder"
         )
 
-    # Reload watch folders in file service to apply changes
-    await file_service.reload_watch_folders()
+    # Reload watch folders in file service only when the set of actively
+    # watched folders changed; rules are read from the DB at ingest time.
+    if "is_active" in updates:
+        await file_service.reload_watch_folders()
 
-    status_text = "activated" if is_active else "deactivated"
     return success_response({
         "status": "updated",
         "folder_path": folder_path,
-        "is_active": is_active,
-        "message": f"Watch folder {status_text} successfully"
+        "updated_fields": list(updates.keys()),
+        "message": "Watch folder updated successfully"
     })
 
 

--- a/src/api/routers/files.py
+++ b/src/api/routers/files.py
@@ -943,6 +943,22 @@ async def reload_watch_folders(
     return result
 
 
+@router.post("/watch-folders/rescan")
+async def rescan_watch_folder(
+    folder_path: str = Query(..., description="Watch folder path to rescan"),
+    file_service: FileService = Depends(get_file_service)
+):
+    """Rescan a single watch folder on demand."""
+    try:
+        result = await file_service.rescan_watch_folder(folder_path)
+    except ValueError as e:
+        raise PrinternizerValidationError(
+            field="folder_path",
+            error=str(e)
+        )
+    return result
+
+
 @router.post("/watch-folders/validate")
 async def validate_watch_folder(
     folder_path: str = Query(..., description="Folder path to validate"),

--- a/src/database/repositories/library_repository.py
+++ b/src/database/repositories/library_repository.py
@@ -572,6 +572,30 @@ class LibraryRepository(BaseRepository):
                         error=str(e), exc_info=True)
             return False
 
+    async def delete_file_source(self, checksum: str, source_type: str, source_id: str) -> bool:
+        """Delete a single source record for a library file.
+
+        Args:
+            checksum: File checksum
+            source_type: Source type (e.g. 'watch_folder', 'printer')
+            source_id: Source identifier (folder path or printer id)
+
+        Returns:
+            True if deletion succeeded, False otherwise
+        """
+        try:
+            await self._execute_write(
+                """DELETE FROM library_file_sources
+                WHERE file_checksum = ? AND source_type = ? AND source_id = ?""",
+                (checksum, source_type, source_id)
+            )
+            return True
+        except Exception as e:
+            logger.error("Failed to delete library file source", checksum=checksum,
+                        source_type=source_type, source_id=source_id,
+                        error=str(e), exc_info=True)
+            return False
+
     async def delete_file_sources(self, checksum: str) -> bool:
         """Delete all sources for a library file.
 

--- a/src/main.py
+++ b/src/main.py
@@ -312,7 +312,11 @@ async def lifespan(app: FastAPI):
         library_service=library_service
     )
     await slicing_queue.initialize()
-    
+
+    # Watch-folder auto-slice workflows need the slicing services, which are
+    # constructed after the watcher (late injection)
+    file_watcher_service.set_slicing_services(slicing_queue, slicer_service)
+
     timer.end("Slicer services initialization")
     logger.info("[OK] Slicer services initialized")
 

--- a/src/models/file.py
+++ b/src/models/file.py
@@ -200,8 +200,9 @@ class WatchFolderItem(BaseModel):
     last_scan_at: Optional[datetime] = None
     is_valid: bool = True
     validation_error: Optional[str] = None
-    # Processing rules (Phase 7b)
+    # Processing rules (Phase 7b/7c)
     auto_tag: bool = False
+    auto_slice: bool = False
     classification: Optional[str] = None
     default_printer_id: Optional[str] = None
     default_profile_id: Optional[str] = None

--- a/src/models/file.py
+++ b/src/models/file.py
@@ -193,6 +193,18 @@ class WatchFolderItem(BaseModel):
     is_active: bool
     created_at: datetime
     updated_at: Optional[datetime] = None
+    recursive: bool = True
+    folder_name: Optional[str] = None
+    # Monitoring status
+    file_count: int = 0
+    last_scan_at: Optional[datetime] = None
+    is_valid: bool = True
+    validation_error: Optional[str] = None
+    # Processing rules (Phase 7b)
+    auto_tag: bool = False
+    classification: Optional[str] = None
+    default_printer_id: Optional[str] = None
+    default_profile_id: Optional[str] = None
 
 class WatchFolderSettings(BaseModel):
     """Watch folder settings response model."""

--- a/src/models/notification.py
+++ b/src/models/notification.py
@@ -27,6 +27,8 @@ class NotificationEventType(str, Enum):
     PRINTER_ERROR = "printer_error"
     MATERIAL_LOW_STOCK = "material_low_stock"
     FILE_DOWNLOADED = "file_downloaded"
+    SLICING_COMPLETED = "slicing_completed"
+    SLICING_FAILED = "slicing_failed"
 
 
 class NotificationStatus(str, Enum):
@@ -207,5 +209,15 @@ EVENT_TYPE_METADATA = {
         "label": "File Downloaded",
         "icon": "download",
         "description": "When a file is downloaded from a printer"
+    },
+    NotificationEventType.SLICING_COMPLETED: {
+        "label": "Slicing Completed",
+        "icon": "layers",
+        "description": "When a slicing job finishes (including watch folder auto-slice)"
+    },
+    NotificationEventType.SLICING_FAILED: {
+        "label": "Slicing Failed",
+        "icon": "alert-triangle",
+        "description": "When a slicing job fails"
     },
 }

--- a/src/models/watch_folder.py
+++ b/src/models/watch_folder.py
@@ -50,6 +50,9 @@ class WatchFolder:
     default_printer_id: Optional[str] = None  # Default printer for workflows (Phase 7c)
     default_profile_id: Optional[str] = None  # Default slicer profile (Phase 7c)
 
+    # Workflows (Phase 7c)
+    auto_slice: bool = False                  # Queue new model files for slicing
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary representation."""
         return {
@@ -70,7 +73,8 @@ class WatchFolder:
             'auto_tag': self.auto_tag,
             'classification': self.classification,
             'default_printer_id': self.default_printer_id,
-            'default_profile_id': self.default_profile_id
+            'default_profile_id': self.default_profile_id,
+            'auto_slice': self.auto_slice
         }
     
     @classmethod
@@ -94,7 +98,8 @@ class WatchFolder:
             auto_tag=bool(data.get('auto_tag', False)),
             classification=data.get('classification'),
             default_printer_id=data.get('default_printer_id'),
-            default_profile_id=data.get('default_profile_id')
+            default_profile_id=data.get('default_profile_id'),
+            auto_slice=bool(data.get('auto_slice', False))
         )
 
     @classmethod
@@ -122,7 +127,8 @@ class WatchFolder:
             auto_tag=bool(row[14]) if len(row) > 14 else False,
             classification=row[15] if len(row) > 15 else None,
             default_printer_id=row[16] if len(row) > 16 else None,
-            default_profile_id=row[17] if len(row) > 17 else None
+            default_profile_id=row[17] if len(row) > 17 else None,
+            auto_slice=bool(row[18]) if len(row) > 18 else False
         )
     
     def get_display_name(self) -> str:

--- a/src/models/watch_folder.py
+++ b/src/models/watch_folder.py
@@ -39,11 +39,17 @@ class WatchFolder:
     
     # Source tracking
     source: WatchFolderSource = WatchFolderSource.MANUAL
-    
+
     # Timestamps
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    
+
+    # Processing rules (Phase 7b)
+    auto_tag: bool = False                    # Tag files with first-level subfolder name
+    classification: Optional[str] = None      # 'business' | 'private' | None
+    default_printer_id: Optional[str] = None  # Default printer for workflows (Phase 7c)
+    default_profile_id: Optional[str] = None  # Default slicer profile (Phase 7c)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary representation."""
         return {
@@ -60,7 +66,11 @@ class WatchFolder:
             'last_validation_at': self.last_validation_at.isoformat() if self.last_validation_at else None,
             'source': self.source.value,
             'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            'auto_tag': self.auto_tag,
+            'classification': self.classification,
+            'default_printer_id': self.default_printer_id,
+            'default_profile_id': self.default_profile_id
         }
     
     @classmethod
@@ -80,12 +90,20 @@ class WatchFolder:
             last_validation_at=datetime.fromisoformat(data['last_validation_at']) if data.get('last_validation_at') else None,
             source=WatchFolderSource(data.get('source', WatchFolderSource.MANUAL.value)),
             created_at=datetime.fromisoformat(data['created_at']) if data.get('created_at') else None,
-            updated_at=datetime.fromisoformat(data['updated_at']) if data.get('updated_at') else None
+            updated_at=datetime.fromisoformat(data['updated_at']) if data.get('updated_at') else None,
+            auto_tag=bool(data.get('auto_tag', False)),
+            classification=data.get('classification'),
+            default_printer_id=data.get('default_printer_id'),
+            default_profile_id=data.get('default_profile_id')
         )
-    
+
     @classmethod
     def from_db_row(cls, row: tuple) -> 'WatchFolder':
-        """Create instance from database row."""
+        """Create instance from database row.
+
+        Rule columns (added in migration 038) are appended at the end of the
+        table; guard against rows from a pre-migration schema.
+        """
         return cls(
             id=row[0],
             folder_path=row[1],
@@ -100,7 +118,11 @@ class WatchFolder:
             last_validation_at=datetime.fromisoformat(row[10]) if row[10] else None,
             source=WatchFolderSource(row[11]),
             created_at=datetime.fromisoformat(row[12]) if row[12] else None,
-            updated_at=datetime.fromisoformat(row[13]) if row[13] else None
+            updated_at=datetime.fromisoformat(row[13]) if row[13] else None,
+            auto_tag=bool(row[14]) if len(row) > 14 else False,
+            classification=row[15] if len(row) > 15 else None,
+            default_printer_id=row[16] if len(row) > 16 else None,
+            default_profile_id=row[17] if len(row) > 17 else None
         )
     
     def get_display_name(self) -> str:

--- a/src/services/config_service.py
+++ b/src/services/config_service.py
@@ -640,11 +640,13 @@ class ConfigService:
         settings = get_settings()
         watch_folders = await self.watch_folder_db.get_all_watch_folders(active_only=True)
         
+        from src.services.file_watcher_service import PrintFileHandler
+
         return {
             "watch_folders": [wf.folder_path for wf in watch_folders],
             "enabled": settings.watch_folders_enabled,
             "recursive": settings.watch_recursive,
-            "supported_extensions": ['.stl', '.3mf', '.gcode', '.obj', '.ply']
+            "supported_extensions": sorted(PrintFileHandler.SUPPORTED_EXTENSIONS)
         }
 
     async def get_system_info(self) -> Dict[str, Any]:

--- a/src/services/file_service.py
+++ b/src/services/file_service.py
@@ -749,6 +749,19 @@ class FileService:
             logger.error("Error reloading watch folders", error=str(e))
             return {"success": False, "error": str(e)}
 
+    async def rescan_watch_folder(self, folder_path: str) -> Dict[str, Any]:
+        """Rescan a single watch folder on demand.
+
+        Raises:
+            ValueError: If the file watcher is unavailable or the folder
+                is not being watched.
+        """
+        if not self.file_watcher:
+            raise ValueError("File watcher not available")
+
+        result = await self.file_watcher.rescan_folder(folder_path)
+        return {"success": True, **result}
+
     # ========================================================================
     # DEPENDENCY INJECTION (for resolving circular dependencies)
     # ========================================================================

--- a/src/services/file_watcher_service.py
+++ b/src/services/file_watcher_service.py
@@ -162,8 +162,18 @@ class FileWatcherService:
 
         self._fallback_scan_task: Optional[asyncio.Task] = None
 
+        # Slicing services for auto-slice workflows; injected after startup
+        # via set_slicing_services() (they are constructed after the watcher).
+        self._slicing_queue = None
+        self._slicer_service = None
+
         # Initialize file handler
         self._file_handler = PrintFileHandler(self)
+
+    def set_slicing_services(self, slicing_queue, slicer_service) -> None:
+        """Inject slicing services for the auto-slice workflow (Phase 7c)."""
+        self._slicing_queue = slicing_queue
+        self._slicer_service = slicer_service
 
     @staticmethod
     def _make_file_id(file_path: str) -> str:
@@ -505,6 +515,10 @@ class FileWatcherService:
             # Store file
             self._local_files[file_id] = local_file
 
+            # Whether this content is new to the library (vs a duplicate of
+            # an existing file); workflows only run for new content.
+            is_new_library_file = False
+
             # Add to library if library service is available and enabled
             if self.library_service and self.library_service.enabled:
                 try:
@@ -537,6 +551,7 @@ class FileWatcherService:
                                     checksum=checksum[:16])
                     else:
                         # New file - copy to library
+                        is_new_library_file = True
                         source_info = {
                             'type': 'watch_folder',
                             'folder_path': watch_folder_path,
@@ -562,9 +577,10 @@ class FileWatcherService:
                                 error=str(e))
                     # Continue anyway - file still tracked locally
 
-                # Apply per-folder processing rules (auto-tags, classification)
+                # Apply per-folder processing rules (auto-tags, classification,
+                # auto-slice for new content)
                 if local_file.checksum:
-                    await self._apply_folder_rules(local_file)
+                    await self._apply_folder_rules(local_file, is_new_file=is_new_library_file)
 
             # Emit file discovered event
             await self._emit_file_event('file_discovered', local_file)
@@ -576,13 +592,14 @@ class FileWatcherService:
             logger.error("Error processing discovered file",
                        file_path=file_path, error=str(e))
 
-    async def _apply_folder_rules(self, local_file: LocalFile) -> None:
+    async def _apply_folder_rules(self, local_file: LocalFile, is_new_file: bool = False) -> None:
         """Apply the watch folder's processing rules to an ingested file.
 
-        Rules (configured per folder, migration 038):
+        Rules (configured per folder, migrations 038/039):
         - auto_tag: tag the file with its first-level subfolder name
           (e.g. ``vases/spiral.stl`` -> tag ``vases``).
         - classification: tag the file as ``business`` or ``private``.
+        - auto_slice: queue new model files for slicing (never starts a print).
         """
         watch_folder_db = getattr(self.config_service, 'watch_folder_db', None)
         if watch_folder_db is None or not local_file.checksum:
@@ -621,6 +638,74 @@ class FileWatcherService:
                        filename=local_file.filename,
                        folder_path=local_file.watch_folder_path,
                        tags=tags)
+
+        # Auto-slice only fires the first time content enters the library,
+        # so rescans and duplicate copies never re-queue slicing jobs.
+        if is_new_file and getattr(folder, 'auto_slice', False):
+            await self._maybe_auto_slice(local_file, folder)
+
+    async def _maybe_auto_slice(self, local_file: LocalFile, folder) -> None:
+        """Queue a slicing job for a newly ingested model file.
+
+        Safety rule: watch-folder automation prepares gcode and notifies —
+        it NEVER uploads to a printer or starts a print (auto_upload and
+        auto_start are always False).
+        """
+        if self._slicing_queue is None or self._slicer_service is None:
+            logger.debug("auto_slice enabled but slicing services not available",
+                        folder_path=local_file.watch_folder_path)
+            return
+
+        profile_id = getattr(folder, 'default_profile_id', None)
+        if not profile_id:
+            logger.info("auto_slice enabled but no default profile configured, skipping",
+                       folder_path=local_file.watch_folder_path,
+                       filename=local_file.filename)
+            return
+
+        # Only slice source models (not gcode or already-sliced 3mf bundles)
+        from src.services.file_role_classifier import classify_role, threemf_has_gcode
+        has_gcode = None
+        if local_file.file_type == '.3mf':
+            has_gcode = threemf_has_gcode(Path(local_file.file_path))
+        if classify_role(local_file.file_type, has_gcode) != 'model':
+            return
+
+        try:
+            slicers = await self._slicer_service.list_slicers(available_only=True)
+            if not slicers:
+                logger.warning("auto_slice: no available slicer configured, skipping",
+                             filename=local_file.filename)
+                return
+
+            from src.models.slicer import SlicingJobRequest
+            request = SlicingJobRequest(
+                file_checksum=local_file.checksum,
+                slicer_id=slicers[0].id,
+                profile_id=profile_id,
+                target_printer_id=getattr(folder, 'default_printer_id', None),
+                auto_upload=False,
+                auto_start=False  # Watch-folder automation never starts prints
+            )
+            job = await self._slicing_queue.create_job(request)
+
+            await self.event_service.emit_event('watch_folder.auto_slice_queued', {
+                'job_id': job.id,
+                'filename': local_file.filename,
+                'checksum': local_file.checksum,
+                'folder_path': local_file.watch_folder_path,
+                'profile_id': profile_id,
+                'target_printer_id': getattr(folder, 'default_printer_id', None)
+            })
+
+            logger.info("Queued auto-slice for watch folder file",
+                       filename=local_file.filename,
+                       job_id=job.id,
+                       profile_id=profile_id)
+
+        except Exception as e:
+            logger.error("Failed to queue auto-slice",
+                        filename=local_file.filename, error=str(e))
 
     def _find_watch_folder_for_file(self, file_path: str) -> Optional[str]:
         """Find which watch folder contains the given file."""

--- a/src/services/file_watcher_service.py
+++ b/src/services/file_watcher_service.py
@@ -562,6 +562,10 @@ class FileWatcherService:
                                 error=str(e))
                     # Continue anyway - file still tracked locally
 
+                # Apply per-folder processing rules (auto-tags, classification)
+                if local_file.checksum:
+                    await self._apply_folder_rules(local_file)
+
             # Emit file discovered event
             await self._emit_file_event('file_discovered', local_file)
 
@@ -571,6 +575,52 @@ class FileWatcherService:
         except Exception as e:
             logger.error("Error processing discovered file",
                        file_path=file_path, error=str(e))
+
+    async def _apply_folder_rules(self, local_file: LocalFile) -> None:
+        """Apply the watch folder's processing rules to an ingested file.
+
+        Rules (configured per folder, migration 038):
+        - auto_tag: tag the file with its first-level subfolder name
+          (e.g. ``vases/spiral.stl`` -> tag ``vases``).
+        - classification: tag the file as ``business`` or ``private``.
+        """
+        watch_folder_db = getattr(self.config_service, 'watch_folder_db', None)
+        if watch_folder_db is None or not local_file.checksum:
+            return
+
+        try:
+            folder = await watch_folder_db.get_watch_folder_by_path(local_file.watch_folder_path)
+        except Exception as e:
+            logger.debug("Could not load watch folder rules",
+                        folder_path=local_file.watch_folder_path, error=str(e))
+            return
+
+        if folder is None:
+            return
+
+        tags = []
+
+        if getattr(folder, 'auto_tag', False):
+            parts = Path(local_file.relative_path).parts
+            if len(parts) > 1:  # File sits in a subfolder
+                tags.append(parts[0])
+
+        classification = getattr(folder, 'classification', None)
+        if classification in ('business', 'private'):
+            tags.append(classification)
+
+        for tag_name in tags:
+            try:
+                await self.library_service.assign_tag_by_name(local_file.checksum, tag_name)
+            except Exception as e:
+                logger.error("Failed to apply folder rule tag",
+                            filename=local_file.filename, tag=tag_name, error=str(e))
+
+        if tags:
+            logger.info("Applied watch folder rules",
+                       filename=local_file.filename,
+                       folder_path=local_file.watch_folder_path,
+                       tags=tags)
 
     def _find_watch_folder_for_file(self, file_path: str) -> Optional[str]:
         """Find which watch folder contains the given file."""

--- a/src/services/file_watcher_service.py
+++ b/src/services/file_watcher_service.py
@@ -6,8 +6,9 @@ Implements cross-platform file system monitoring using watchdog.
 import os
 import sys
 import asyncio
+import hashlib
 import threading
-from typing import Dict, List, Set, Optional, Callable, Any, TYPE_CHECKING
+from typing import Dict, List, Set, Optional, Callable, Any, Coroutine, TYPE_CHECKING
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
@@ -37,29 +38,35 @@ class LocalFile:
     modified_time: datetime
     watch_folder_path: str
     relative_path: str
+    checksum: Optional[str] = None
 
 
 class PrintFileHandler(FileSystemEventHandler):
-    """File system event handler for 3D print files."""
-    
-    SUPPORTED_EXTENSIONS = {'.stl', '.3mf', '.gcode', '.obj', '.ply'}
+    """File system event handler for 3D print files.
+
+    Note: watchdog invokes these callbacks on its own observer thread,
+    so all async work must be handed to the main event loop via
+    FileWatcherService._schedule_from_thread().
+    """
+
+    SUPPORTED_EXTENSIONS = {'.stl', '.3mf', '.gcode', '.bgcode', '.obj', '.ply'}
     IGNORED_PATTERNS = {'*.tmp', '*.temp', '.*', '*~', '*.lock'}
-    
+
     def __init__(self, file_watcher: 'FileWatcherService'):
         """Initialize file handler."""
         super().__init__()
         self.file_watcher = file_watcher
         self._debounce_events = {}  # File path -> event time for debouncing
         self._debounce_delay = 1.0  # 1 second debounce delay
-    
+
     def should_process_file(self, file_path: str) -> bool:
         """Check if file should be processed based on extension and patterns."""
         path = Path(file_path)
-        
+
         # Check extension
         if path.suffix.lower() not in self.SUPPORTED_EXTENSIONS:
             return False
-        
+
         # Check ignored patterns
         for pattern in self.IGNORED_PATTERNS:
             if pattern.startswith('*'):
@@ -68,54 +75,70 @@ class PrintFileHandler(FileSystemEventHandler):
             elif pattern.startswith('.'):
                 if path.name.startswith('.'):
                     return False
-        
+
         return True
-    
+
     def _debounce_event(self, file_path: str) -> bool:
         """Debounce file events to avoid duplicate processing."""
         now = datetime.now()
-        
+
         if file_path in self._debounce_events:
             last_event = self._debounce_events[file_path]
             if (now - last_event).total_seconds() < self._debounce_delay:
                 return False  # Skip this event
-        
+
         self._debounce_events[file_path] = now
         return True
-    
+
     def on_created(self, event: FileSystemEvent) -> None:
         """Handle file creation events."""
         if not event.is_directory and self.should_process_file(event.src_path):
             if self._debounce_event(event.src_path):
                 logger.info("New print file detected", file_path=event.src_path)
-                asyncio.create_task(self.file_watcher._handle_file_created(event.src_path))
+                self.file_watcher._schedule_from_thread(
+                    self.file_watcher._handle_file_created(event.src_path)
+                )
 
     def on_modified(self, event: FileSystemEvent) -> None:
         """Handle file modification events."""
         if not event.is_directory and self.should_process_file(event.src_path):
             if self._debounce_event(event.src_path):
                 logger.debug("Print file modified", file_path=event.src_path)
-                asyncio.create_task(self.file_watcher._handle_file_modified(event.src_path))
+                self.file_watcher._schedule_from_thread(
+                    self.file_watcher._handle_file_modified(event.src_path)
+                )
 
     def on_deleted(self, event: FileSystemEvent) -> None:
         """Handle file deletion events."""
         if not event.is_directory and self.should_process_file(event.src_path):
             logger.info("Print file deleted", file_path=event.src_path)
-            asyncio.create_task(self.file_watcher._handle_file_deleted(event.src_path))
-    
+            self.file_watcher._schedule_from_thread(
+                self.file_watcher._handle_file_deleted(event.src_path)
+            )
+
     def on_moved(self, event: FileSystemEvent) -> None:
         """Handle file move/rename events."""
         if hasattr(event, 'dest_path'):
             if not event.is_directory and self.should_process_file(event.dest_path):
-                logger.info("Print file moved", 
+                logger.info("Print file moved",
                           old_path=event.src_path, new_path=event.dest_path)
-                asyncio.create_task(
+                self.file_watcher._schedule_from_thread(
                     self.file_watcher._handle_file_moved(event.src_path, event.dest_path)
                 )
 
 
 class FileWatcherService:
     """Service for watching local folders for 3D print files."""
+
+    # Seconds between size/mtime probes when waiting for a file to finish
+    # being written, and the cap on how long to wait (large files copied
+    # over the network can take minutes).
+    STABILITY_CHECK_INTERVAL = 0.5
+    STABILITY_TIMEOUT = 300.0
+
+    # Rescan cadence when the watchdog observer could not be started
+    # (fallback mode has no real-time events).
+    FALLBACK_RESCAN_INTERVAL = 300.0
 
     def __init__(self, config_service: ConfigService, event_service: EventService, library_service=None):
         """Initialize file watcher service."""
@@ -129,21 +152,57 @@ class FileWatcherService:
         self._is_running = False
         self._lock = threading.Lock()
 
+        # Event loop the service was started on; watchdog callbacks run on
+        # the observer thread and must schedule coroutines onto this loop.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+        # Paths currently being stabilized/ingested (suppresses duplicate
+        # created/modified bursts while a copy is still in progress).
+        self._processing_paths: Set[str] = set()
+
+        self._fallback_scan_task: Optional[asyncio.Task] = None
+
         # Initialize file handler
         self._file_handler = PrintFileHandler(self)
-    
+
+    @staticmethod
+    def _make_file_id(file_path: str) -> str:
+        """Deterministic file ID for a path (stable across restarts)."""
+        return f"local_{hashlib.sha1(file_path.encode('utf-8')).hexdigest()[:16]}"
+
+    def _schedule_from_thread(self, coro: Coroutine) -> None:
+        """Schedule a coroutine from any thread onto the service's event loop.
+
+        Watchdog handlers run on the observer thread where no event loop is
+        running, so plain asyncio.create_task() would raise RuntimeError.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            loop = self._loop
+            if loop is not None and not loop.is_closed():
+                asyncio.run_coroutine_threadsafe(coro, loop)
+            else:
+                coro.close()
+                logger.warning("Dropped file event: no event loop available")
+            return
+        # Already on a loop thread (e.g. direct calls in tests)
+        asyncio.create_task(coro)
+
     async def start(self) -> None:
         """Start file watcher service."""
         if self._is_running:
             logger.warning("File watcher service already running")
             return
-        
+
         logger.debug("FileWatcher debug", config_service_type=type(self.config_service).__name__, event_service_type=type(self.event_service).__name__)
-        
+
         if not self.config_service.is_watch_folders_enabled():
             logger.info("Watch folders disabled in configuration")
             return
-        
+
+        self._loop = asyncio.get_running_loop()
+
         try:
             # Initialize observer with platform-specific handling
             # Use PollingObserver on Windows to avoid threading issues
@@ -153,28 +212,28 @@ class FileWatcherService:
             else:
                 self._observer = Observer()
                 logger.debug("Using native Observer for file watching")
-            
+
             # Add watch folders
             watch_folders = await self.config_service.get_watch_folders()
             recursive = self.config_service.is_recursive_watching_enabled()
-            
+
             for folder_path in watch_folders:
                 await self._add_watch_folder(folder_path, recursive)
-            
+
             # Start observer
             try:
                 # Start observer in the main thread (Windows compatible)
                 # Watchdog Observer creates its own threads internally
                 self._observer.start()
                 self._is_running = True
-                
-                logger.info("File watcher service started", 
+
+                logger.info("File watcher service started",
                            watched_folders=len(self._watched_folders),
                            recursive=recursive,
                            observer_type=type(self._observer).__name__)
             except Exception as e:
-                logger.warning("Failed to start watchdog observer, running in fallback mode", 
-                             error=str(e), 
+                logger.warning("Failed to start watchdog observer, running in fallback mode",
+                             error=str(e),
                              observer_type=type(self._observer).__name__ if self._observer else "None",
                              platform=sys.platform)
                 # Fallback mode - file watcher API still works, but no real-time watching
@@ -186,54 +245,66 @@ class FileWatcherService:
                                     error=str(stop_error))
                 self._observer = None
                 self._is_running = True  # Mark as running so API endpoints work
-            
+
             # Perform initial scan
             await self._initial_scan()
-            
+
+            # Without an observer there are no real-time events, so poll
+            # the folders periodically instead of silently going blind.
+            if self._observer is None and self._watched_folders:
+                self._fallback_scan_task = asyncio.create_task(self._fallback_rescan_loop())
+                logger.info("Started periodic fallback rescan",
+                           interval_seconds=self.FALLBACK_RESCAN_INTERVAL)
+
         except Exception as e:
             logger.error("Failed to start file watcher service", error=str(e))
             # Still mark as running in fallback mode
             self._is_running = True
             logger.info("File watcher running in fallback mode (API only, no real-time monitoring)")
-    
+
     async def stop(self):
         """Stop file watcher service."""
         if not self._is_running:
             return
-        
+
         try:
+            if self._fallback_scan_task:
+                self._fallback_scan_task.cancel()
+                self._fallback_scan_task = None
+
             with self._lock:
                 if self._observer:
                     try:
                         # Stop observer gracefully
                         self._observer.stop()
-                        
+
                         # Wait for observer thread to finish with timeout
                         if hasattr(self._observer, 'is_alive') and self._observer.is_alive():
                             # Run join in executor to avoid blocking async loop
                             loop = asyncio.get_running_loop()
                             await loop.run_in_executor(
-                                None, 
+                                None,
                                 lambda: self._observer.join(timeout=5.0)
                             )
-                            
+
                             # Force stop if still alive
                             if hasattr(self._observer, 'is_alive') and self._observer.is_alive():
                                 logger.warning("Observer thread did not stop gracefully, forcing termination")
-                                
+
                     except Exception as e:
                         logger.warning("Error stopping observer", error=str(e))
                     finally:
                         self._observer = None
-                
+
                 self._watched_folders.clear()
+                self._processing_paths.clear()
                 self._is_running = False
-            
+
             logger.info("File watcher service stopped")
-            
+
         except Exception as e:
             logger.error("Error stopping file watcher service", error=str(e))
-    
+
     async def _add_watch_folder(self, folder_path: str, recursive: bool = True):
         """Add a folder to watch list."""
         try:
@@ -272,37 +343,127 @@ class FileWatcherService:
         except Exception as e:
             logger.error("Failed to add watch folder",
                        folder_path=folder_path, error=str(e))
-    
+
     async def _initial_scan(self):
         """Perform initial scan of all watched folders."""
         logger.info("Starting initial scan of watch folders")
-        
+
         for folder_path, folder_info in self._watched_folders.items():
             try:
-                await self._scan_folder(folder_info['path'], folder_info['recursive'])
-                
+                file_count = await self._scan_folder(folder_info['path'], folder_info['recursive'])
+                await self._update_folder_stats(folder_path, file_count)
+
             except Exception as e:
-                logger.error("Error during initial scan", 
+                logger.error("Error during initial scan",
                            folder_path=folder_path, error=str(e))
-        
+
         logger.info("Initial scan completed", discovered_files=len(self._local_files))
-    
-    async def _scan_folder(self, folder_path: Path, recursive: bool = True):
-        """Scan a folder for existing 3D print files."""
+
+    async def _scan_folder(self, folder_path: Path, recursive: bool = True) -> int:
+        """Scan a folder for existing 3D print files. Returns number of files found."""
+        file_count = 0
         try:
             if recursive:
                 pattern = "**/*"
             else:
                 pattern = "*"
-            
+
             for file_path in folder_path.glob(pattern):
                 if file_path.is_file() and self._file_handler.should_process_file(str(file_path)):
                     await self._process_discovered_file(str(file_path))
-                    
+                    file_count += 1
+
         except Exception as e:
-            logger.error("Error scanning folder", 
+            logger.error("Error scanning folder",
                        folder_path=str(folder_path), error=str(e))
-    
+        return file_count
+
+    async def _update_folder_stats(self, folder_path: str, file_count: int) -> None:
+        """Persist per-folder scan statistics (file count, last scan time)."""
+        watch_folder_db = getattr(self.config_service, 'watch_folder_db', None)
+        if watch_folder_db is None:
+            return
+        try:
+            await watch_folder_db.update_folder_statistics(folder_path, file_count)
+        except Exception as e:
+            logger.debug("Could not update watch folder statistics",
+                        folder_path=folder_path, error=str(e))
+
+    async def rescan_folder(self, folder_path: str) -> Dict[str, Any]:
+        """Rescan a single watch folder on demand.
+
+        Raises:
+            ValueError: If the folder is not currently being watched.
+        """
+        folder_info = self._watched_folders.get(folder_path)
+        if not folder_info:
+            raise ValueError(f"Folder is not being watched: {folder_path}")
+
+        known_before = {
+            f.file_path for f in self._local_files.values()
+            if f.watch_folder_path == folder_path
+        }
+
+        file_count = await self._scan_folder(folder_info['path'], folder_info['recursive'])
+        await self._update_folder_stats(folder_path, file_count)
+
+        known_after = {
+            f.file_path for f in self._local_files.values()
+            if f.watch_folder_path == folder_path
+        }
+
+        result = {
+            'folder_path': folder_path,
+            'files_found': file_count,
+            'new_files': len(known_after - known_before)
+        }
+        logger.info("Rescanned watch folder", **result)
+        return result
+
+    async def _fallback_rescan_loop(self) -> None:
+        """Periodically rescan folders when real-time watching is unavailable."""
+        while True:
+            await asyncio.sleep(self.FALLBACK_RESCAN_INTERVAL)
+            for folder_path, folder_info in list(self._watched_folders.items()):
+                try:
+                    file_count = await self._scan_folder(folder_info['path'], folder_info['recursive'])
+                    await self._update_folder_stats(folder_path, file_count)
+                except Exception as e:
+                    logger.error("Error during fallback rescan",
+                               folder_path=folder_path, error=str(e))
+
+    async def _wait_for_file_stable(self, path: Path) -> bool:
+        """Wait until a file's size/mtime stop changing (write finished).
+
+        Protects against ingesting a file that is still being copied into
+        the watch folder, which would store a truncated copy with a wrong
+        checksum in the library.
+
+        Returns True once stable, False if the file vanished or the
+        stability timeout was exceeded.
+        """
+        try:
+            last_stat = path.stat()
+        except OSError:
+            return False
+
+        deadline = asyncio.get_running_loop().time() + self.STABILITY_TIMEOUT
+        while True:
+            await asyncio.sleep(self.STABILITY_CHECK_INTERVAL)
+            try:
+                current_stat = path.stat()
+            except OSError:
+                return False  # Deleted/moved while waiting
+
+            if (current_stat.st_size, current_stat.st_mtime) == (last_stat.st_size, last_stat.st_mtime):
+                return True
+
+            last_stat = current_stat
+            if asyncio.get_running_loop().time() > deadline:
+                logger.warning("File did not stabilize within timeout, skipping",
+                             file_path=str(path), timeout=self.STABILITY_TIMEOUT)
+                return False
+
     async def _process_discovered_file(self, file_path: str):
         """Process a discovered file and add to local files and library."""
         try:
@@ -326,8 +487,8 @@ class FileWatcherService:
             except ValueError:
                 relative_path = Path(path.name)
 
-            # Generate file ID
-            file_id = f"local_{abs(hash(file_path))}"
+            # Generate deterministic file ID (stable across restarts)
+            file_id = self._make_file_id(file_path)
 
             # Create LocalFile object
             local_file = LocalFile(
@@ -349,6 +510,7 @@ class FileWatcherService:
                 try:
                     # Calculate checksum to check for duplicates
                     checksum = await self.library_service.calculate_checksum(path)
+                    local_file.checksum = checksum
 
                     # Check if file already exists in library (by checksum)
                     existing_file = await self.library_service.get_file_by_checksum(checksum)
@@ -409,88 +571,161 @@ class FileWatcherService:
         except Exception as e:
             logger.error("Error processing discovered file",
                        file_path=file_path, error=str(e))
-    
+
     def _find_watch_folder_for_file(self, file_path: str) -> Optional[str]:
         """Find which watch folder contains the given file."""
         file_path_obj = Path(file_path)
-        
+
         for watch_folder_path in self._watched_folders.keys():
             watch_path = Path(watch_folder_path)
-            
+
             try:
                 file_path_obj.relative_to(watch_path)
                 return watch_folder_path
             except ValueError:
                 continue
-        
+
         return None
-    
-    async def _handle_file_created(self, file_path: str):
-        """Handle file creation event."""
-        await self._process_discovered_file(file_path)
-    
-    async def _handle_file_modified(self, file_path: str):
-        """Handle file modification event."""
-        # Find existing file
+
+    def _find_local_file_by_path(self, file_path: str) -> Optional[LocalFile]:
+        """Find a tracked local file by its absolute path."""
         for local_file in self._local_files.values():
             if local_file.file_path == file_path:
-                # Update file information
+                return local_file
+        return None
+
+    async def _remove_library_source(self, checksum: Optional[str], watch_folder_path: str) -> None:
+        """Remove a watch-folder source from a library file, if possible."""
+        if not checksum or not self.library_service or not self.library_service.enabled:
+            return
+        try:
+            await self.library_service.remove_file_source(
+                checksum, 'watch_folder', watch_folder_path
+            )
+        except Exception as e:
+            logger.error("Failed to remove watch folder source from library",
+                        checksum=checksum[:16], folder_path=watch_folder_path,
+                        error=str(e))
+
+    async def _handle_file_created(self, file_path: str):
+        """Handle file creation event."""
+        if file_path in self._processing_paths:
+            return
+        self._processing_paths.add(file_path)
+        try:
+            if not await self._wait_for_file_stable(Path(file_path)):
+                logger.debug("File vanished or never stabilized, skipping",
+                            file_path=file_path)
+                return
+            await self._process_discovered_file(file_path)
+        finally:
+            self._processing_paths.discard(file_path)
+
+    async def _handle_file_modified(self, file_path: str):
+        """Handle file modification event."""
+        if file_path in self._processing_paths:
+            return
+        self._processing_paths.add(file_path)
+        try:
+            if not await self._wait_for_file_stable(Path(file_path)):
+                return
+
+            existing = self._find_local_file_by_path(file_path)
+            old_checksum = existing.checksum if existing else None
+
+            # Update in-memory file information
+            if existing:
                 try:
                     path = Path(file_path)
                     if path.exists():
                         stat = path.stat()
-                        local_file.file_size = stat.st_size
-                        local_file.modified_time = datetime.fromtimestamp(stat.st_mtime)
-                        
-                        await self._emit_file_event('file_modified', local_file)
-                        
-                        logger.debug("Updated local file", 
-                                   filename=local_file.filename)
+                        existing.file_size = stat.st_size
+                        existing.modified_time = datetime.fromtimestamp(stat.st_mtime)
+
+                        await self._emit_file_event('file_modified', existing)
+
+                        logger.debug("Updated local file",
+                                   filename=existing.filename)
                 except Exception as e:
-                    logger.error("Error updating file info", 
+                    logger.error("Error updating file info",
                                file_path=file_path, error=str(e))
-                break
-    
+
+            # Re-ingest so changed content reaches the library
+            await self._process_discovered_file(file_path)
+
+            # If the content changed, the old library record no longer has
+            # this path as a valid source
+            updated = self._find_local_file_by_path(file_path)
+            new_checksum = updated.checksum if updated else None
+            if old_checksum and new_checksum and old_checksum != new_checksum and updated:
+                await self._remove_library_source(old_checksum, updated.watch_folder_path)
+        finally:
+            self._processing_paths.discard(file_path)
+
     async def _handle_file_deleted(self, file_path: str):
         """Handle file deletion event."""
         # Find and remove file
         for file_id, local_file in list(self._local_files.items()):
             if local_file.file_path == file_path:
                 del self._local_files[file_id]
-                
+
                 await self._emit_file_event('file_deleted', local_file)
-                
-                logger.debug("Removed local file", 
+
+                # The library keeps its copy, but this watch folder is no
+                # longer a valid source for it
+                await self._remove_library_source(
+                    local_file.checksum, local_file.watch_folder_path
+                )
+
+                logger.debug("Removed local file",
                            filename=local_file.filename, file_id=file_id)
                 break
-    
+
     async def _handle_file_moved(self, old_path: str, new_path: str):
         """Handle file move/rename event."""
         # Update file path in local files
         for local_file in self._local_files.values():
             if local_file.file_path == old_path:
+                old_watch_folder = local_file.watch_folder_path
+
                 # Update file information
                 path = Path(new_path)
                 local_file.file_path = str(path)
                 local_file.filename = path.name
-                
+
                 # Update relative path
                 watch_folder_path = self._find_watch_folder_for_file(new_path)
                 if watch_folder_path:
                     watch_path = Path(watch_folder_path)
+                    local_file.watch_folder_path = watch_folder_path
                     try:
                         relative_path = path.relative_to(watch_path)
                         local_file.relative_path = str(relative_path)
                     except ValueError:
                         local_file.relative_path = path.name
-                
+
                 await self._emit_file_event('file_moved', local_file)
-                
-                logger.debug("Updated file path", 
+
+                # Moved to a different watch folder: swap the library source
+                if watch_folder_path and watch_folder_path != old_watch_folder and local_file.checksum:
+                    await self._remove_library_source(local_file.checksum, old_watch_folder)
+                    if self.library_service and self.library_service.enabled:
+                        try:
+                            await self.library_service.add_file_source(local_file.checksum, {
+                                'type': 'watch_folder',
+                                'folder_path': watch_folder_path,
+                                'relative_path': local_file.relative_path,
+                                'discovered_at': datetime.now().isoformat()
+                            })
+                        except Exception as e:
+                            logger.error("Failed to add new watch folder source after move",
+                                        checksum=local_file.checksum[:16], error=str(e))
+
+                logger.debug("Updated file path",
                            old_path=old_path, new_path=new_path,
                            filename=local_file.filename)
                 break
-    
+
     async def _emit_file_event(self, event_type: str, local_file: LocalFile):
         """Emit file event through event service."""
         try:
@@ -504,19 +739,20 @@ class FileWatcherService:
                 'modified_time': local_file.modified_time.isoformat(),
                 'watch_folder_path': local_file.watch_folder_path,
                 'relative_path': local_file.relative_path,
+                'checksum': local_file.checksum,
                 'source': 'local_watch'
             }
-            
+
             await self.event_service.emit_event('file_watcher', event_data)
-            
+
         except Exception as e:
-            logger.error("Error emitting file event", 
+            logger.error("Error emitting file event",
                        event_type=event_type, error=str(e))
-    
+
     def get_local_files(self) -> List[Dict[str, Any]]:
         """Get list of all discovered local files."""
         result = []
-        
+
         for local_file in self._local_files.values():
             result.append({
                 'id': local_file.file_id,
@@ -527,36 +763,38 @@ class FileWatcherService:
                 'modified_time': local_file.modified_time.isoformat(),
                 'watch_folder_path': local_file.watch_folder_path,
                 'relative_path': local_file.relative_path,
+                'checksum': local_file.checksum,
                 'status': 'local',
                 'source': 'local_watch'
             })
-        
+
         return result
-    
+
     def get_watch_status(self) -> Dict[str, Any]:
         """Get file watcher service status."""
         return {
             'is_running': self._is_running,
+            'realtime_monitoring': self._observer is not None,
             'watched_folders': list(self._watched_folders.keys()),
             'local_files_count': len(self._local_files),
             'supported_extensions': list(self._file_handler.SUPPORTED_EXTENSIONS)
         }
-    
+
     async def reload_watch_folders(self) -> None:
         """Reload watch folders from configuration."""
         if not self._is_running:
             logger.warning("Cannot reload: file watcher not running")
             return
-        
+
         try:
             # Stop current watching
             await self.stop()
-            
+
             # Restart with new configuration
             await self.start()
-            
+
             logger.info("Reloaded watch folders configuration")
-            
+
         except Exception as e:
             logger.error("Error reloading watch folders", error=str(e))
             raise

--- a/src/services/library_service.py
+++ b/src/services/library_service.py
@@ -602,6 +602,41 @@ class LibraryService:
             'metadata': json.dumps(source_info)
         })
 
+    async def remove_file_source(self, checksum: str, source_type: str, source_id: str) -> None:
+        """
+        Remove a source from an existing file (the file itself is kept).
+
+        Used e.g. when a watch-folder original is deleted: the library copy
+        stays, but the folder is no longer a valid source for it.
+
+        Args:
+            checksum: File checksum
+            source_type: Source type (e.g. 'watch_folder', 'printer')
+            source_id: Source identifier (folder path or printer id)
+        """
+        file_record = await self.get_file_by_checksum(checksum)
+        if not file_record:
+            return
+
+        # Update sources JSON array in main record
+        sources = json.loads(file_record.get('sources', '[]') or '[]')
+        remaining = [
+            s for s in sources
+            if not (s.get('type') == source_type
+                    and (s.get('printer_id') or s.get('folder_path')) == source_id)
+        ]
+
+        if len(remaining) != len(sources):
+            await self.library_repo.update_file(checksum, {
+                'sources': json.dumps(remaining)
+            })
+
+        # Remove from junction table
+        await self.library_repo.delete_file_source(checksum, source_type, source_id)
+
+        logger.info("Removed source from file", checksum=checksum[:16],
+                   source_type=source_type, source_id=source_id)
+
     async def delete_file(self, checksum: str, delete_physical: bool = True) -> bool:
         """
         Delete file from library.

--- a/src/services/library_service.py
+++ b/src/services/library_service.py
@@ -602,6 +602,59 @@ class LibraryService:
             'metadata': json.dumps(source_info)
         })
 
+    async def assign_tag_by_name(self, checksum: str, tag_name: str) -> bool:
+        """
+        Assign a tag to a library file by tag name, creating the tag if needed.
+
+        Used by watch-folder processing rules (auto-tagging, business/private
+        classification). Tag names are matched case-insensitively; the
+        usage_count is maintained by database triggers.
+
+        Args:
+            checksum: File checksum
+            tag_name: Tag name to assign
+
+        Returns:
+            True if the tag was assigned (or already present), False otherwise
+        """
+        name = (tag_name or '').strip()
+        if not name or len(name) > 50:
+            return False
+
+        try:
+            async with self.database.connection() as conn:
+                cursor = await conn.execute(
+                    "SELECT id FROM file_tags WHERE LOWER(name) = LOWER(?)",
+                    (name,)
+                )
+                row = await cursor.fetchone()
+
+                if row:
+                    tag_id = row['id']
+                else:
+                    tag_id = f"tag_{uuid4().hex[:12]}"
+                    now = datetime.now().isoformat()
+                    await conn.execute(
+                        """INSERT INTO file_tags (id, name, usage_count, created_at, updated_at)
+                        VALUES (?, ?, 0, ?, ?)""",
+                        (tag_id, name, now, now)
+                    )
+
+                await conn.execute(
+                    """INSERT OR IGNORE INTO file_tag_assignments (file_checksum, tag_id)
+                    VALUES (?, ?)""",
+                    (checksum, tag_id)
+                )
+                await conn.commit()
+
+            logger.debug("Assigned tag to file", checksum=checksum[:16], tag=name)
+            return True
+
+        except Exception as e:
+            logger.error("Failed to assign tag to file", checksum=checksum[:16],
+                        tag=name, error=str(e))
+            return False
+
     async def remove_file_source(self, checksum: str, source_type: str, source_id: str) -> None:
         """
         Remove a source from an existing file (the file itself is kept).

--- a/src/services/notification_adapters/base_adapter.py
+++ b/src/services/notification_adapters/base_adapter.py
@@ -87,6 +87,8 @@ class BaseNotificationAdapter(ABC):
             'printer_error': 'Printer Error',
             'material_low_stock': 'Material Low Stock',
             'file_downloaded': 'File Downloaded',
+            'slicing_completed': 'Slicing Completed',
+            'slicing_failed': 'Slicing Failed',
             'test': 'Test Notification',
         }
         return titles.get(event_type, event_type.replace('_', ' ').title())
@@ -111,6 +113,8 @@ class BaseNotificationAdapter(ABC):
             'printer_error': '\u26a0\ufe0f',    # Warning sign
             'material_low_stock': '\ud83e\uddf5',  # Thread/spool
             'file_downloaded': '\ud83d\udce5',  # Inbox tray
+            'slicing_completed': '\ud83e\uddc1',  # Layered cake slice
+            'slicing_failed': '\u26a0\ufe0f',   # Warning sign
             'test': '\ud83d\udd14',             # Bell
         }
         return emojis.get(event_type, '\ud83d\udce2')  # Default: megaphone

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -43,6 +43,8 @@ EVENT_MAPPINGS = {
     'printer_disconnected': NotificationEventType.PRINTER_OFFLINE,
     'material_low_stock': NotificationEventType.MATERIAL_LOW_STOCK,
     'file_download_complete': NotificationEventType.FILE_DOWNLOADED,
+    'slicing_job.completed': NotificationEventType.SLICING_COMPLETED,
+    'slicing_job.failed': NotificationEventType.SLICING_FAILED,
 }
 
 
@@ -119,6 +121,10 @@ class NotificationService(BaseService):
 
         # Subscribe to file events
         self.event_service.subscribe('file_download_complete', self._on_file_downloaded)
+
+        # Subscribe to slicing events (auto-slice workflows and manual slicing)
+        self.event_service.subscribe('slicing_job.completed', self._on_slicing_completed)
+        self.event_service.subscribe('slicing_job.failed', self._on_slicing_failed)
 
         logger.info("NotificationService subscribed to events")
 
@@ -240,6 +246,20 @@ class NotificationService(BaseService):
         """Handle file downloaded event."""
         await self._dispatch_notification(
             NotificationEventType.FILE_DOWNLOADED,
+            data
+        )
+
+    async def _on_slicing_completed(self, data: Dict[str, Any]) -> None:
+        """Handle slicing job completed event."""
+        await self._dispatch_notification(
+            NotificationEventType.SLICING_COMPLETED,
+            data
+        )
+
+    async def _on_slicing_failed(self, data: Dict[str, Any]) -> None:
+        """Handle slicing job failed event."""
+        await self._dispatch_notification(
+            NotificationEventType.SLICING_FAILED,
             data
         )
 

--- a/src/services/slicing_queue.py
+++ b/src/services/slicing_queue.py
@@ -466,7 +466,14 @@ class SlicingQueue(BaseService):
                 output_file=str(output_file)
             )
 
-            await self.event_service.emit_event("slicing_job.completed", {"job_id": job_id})
+            await self.event_service.emit_event("slicing_job.completed", {
+                "job_id": job_id,
+                "filename": input_file.name,
+                "output_file": output_file.name,
+                "file_checksum": job.file_checksum,
+                "profile_id": job.profile_id,
+                "printer_id": job.target_printer_id
+            })
             
             # Handle auto-upload if enabled
             if job.auto_upload and job.target_printer_id:
@@ -515,7 +522,13 @@ class SlicingQueue(BaseService):
                     )
                     await conn.commit()
                 
-                await self.event_service.emit_event("slicing_job.failed", {"job_id": job_id, "error": str(e)})
+                await self.event_service.emit_event("slicing_job.failed", {
+                    "job_id": job_id,
+                    "error": str(e),
+                    "file_checksum": job.file_checksum,
+                    "profile_id": job.profile_id,
+                    "printer_id": job.target_printer_id
+                })
         
         finally:
             # Remove from running jobs

--- a/src/services/watch_folder_db_service.py
+++ b/src/services/watch_folder_db_service.py
@@ -136,10 +136,11 @@ class WatchFolderDbService:
             values = []
             
             for key, value in updates.items():
-                if key in ['folder_path', 'folder_name', 'description', 'validation_error', 'source']:
+                if key in ['folder_path', 'folder_name', 'description', 'validation_error', 'source',
+                           'classification', 'default_printer_id', 'default_profile_id']:
                     set_clauses.append(f"{key} = ?")
                     values.append(value)
-                elif key in ['is_active', 'recursive', 'is_valid']:
+                elif key in ['is_active', 'recursive', 'is_valid', 'auto_tag']:
                     set_clauses.append(f"{key} = ?")
                     values.append(bool(value))
                 elif key == 'file_count':

--- a/src/services/watch_folder_db_service.py
+++ b/src/services/watch_folder_db_service.py
@@ -140,7 +140,7 @@ class WatchFolderDbService:
                            'classification', 'default_printer_id', 'default_profile_id']:
                     set_clauses.append(f"{key} = ?")
                     values.append(value)
-                elif key in ['is_active', 'recursive', 'is_valid', 'auto_tag']:
+                elif key in ['is_active', 'recursive', 'is_valid', 'auto_tag', 'auto_slice']:
                     set_clauses.append(f"{key} = ?")
                     values.append(bool(value))
                 elif key == 'file_count':

--- a/tests/services/test_file_watcher_service.py
+++ b/tests/services/test_file_watcher_service.py
@@ -1004,6 +1004,135 @@ class TestFileWatcherServiceFolderRules:
         library.assign_tag_by_name.assert_not_awaited()
 
 
+class TestFileWatcherServiceAutoSlice:
+    """Test the auto-slice workflow (Phase 7c)."""
+
+    def _make_service(self, folder, slicers='default'):
+        mock_config = MagicMock()
+        mock_config.watch_folder_db.get_watch_folder_by_path = AsyncMock(return_value=folder)
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+        library = MagicMock()
+        library.enabled = True
+        library.assign_tag_by_name = AsyncMock(return_value=True)
+
+        service = FileWatcherService(mock_config, mock_event, library)
+
+        queue = MagicMock()
+        job = MagicMock()
+        job.id = "job_1"
+        queue.create_job = AsyncMock(return_value=job)
+
+        slicer_service = MagicMock()
+        if slicers == 'default':
+            slicer = MagicMock()
+            slicer.id = "slicer_1"
+            slicers = [slicer]
+        slicer_service.list_slicers = AsyncMock(return_value=slicers)
+
+        service.set_slicing_services(queue, slicer_service)
+        return service, queue
+
+    def _local_file(self, relative_path="vases/spiral.stl", checksum="abc123"):
+        return LocalFile(
+            file_id="local_1",
+            filename=Path(relative_path).name,
+            file_path=f"/watch/{relative_path}",
+            file_size=100,
+            file_type=Path(relative_path).suffix.lower(),
+            modified_time=datetime.now(),
+            watch_folder_path="/watch",
+            relative_path=relative_path,
+            checksum=checksum
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_slice_queues_new_model_and_never_prints(self):
+        """Test a new model is queued with auto_start/auto_upload off."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_slice=True,
+                             default_profile_id="prof_1", default_printer_id="printer_1")
+
+        service, queue = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file(), is_new_file=True)
+
+        queue.create_job.assert_awaited_once()
+        request = queue.create_job.await_args.args[0]
+        assert request.profile_id == "prof_1"
+        assert request.target_printer_id == "printer_1"
+        assert request.slicer_id == "slicer_1"
+        # The safety rule: watch-folder automation never starts prints
+        assert request.auto_start is False
+        assert request.auto_upload is False
+
+    @pytest.mark.asyncio
+    async def test_auto_slice_skips_duplicate_content(self):
+        """Test re-ingested/duplicate content is not sliced again."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_slice=True,
+                             default_profile_id="prof_1")
+
+        service, queue = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file(), is_new_file=False)
+
+        queue.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_slice_requires_default_profile(self):
+        """Test auto_slice without a default profile does nothing."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_slice=True)
+
+        service, queue = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file(), is_new_file=True)
+
+        queue.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_slice_skips_printfiles(self):
+        """Test gcode files are never auto-sliced."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_slice=True,
+                             default_profile_id="prof_1")
+
+        service, queue = self._make_service(folder)
+        await service._apply_folder_rules(
+            self._local_file("prints/part.gcode"), is_new_file=True)
+
+        queue.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_slice_skips_without_available_slicer(self):
+        """Test missing slicer configuration skips gracefully."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_slice=True,
+                             default_profile_id="prof_1")
+
+        service, queue = self._make_service(folder, slicers=[])
+        await service._apply_folder_rules(self._local_file(), is_new_file=True)
+
+        queue.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_slice_without_injected_services(self):
+        """Test auto_slice is a no-op when slicing services are absent."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_slice=True,
+                             default_profile_id="prof_1")
+
+        mock_config = MagicMock()
+        mock_config.watch_folder_db.get_watch_folder_by_path = AsyncMock(return_value=folder)
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+        library = MagicMock()
+        library.enabled = True
+        library.assign_tag_by_name = AsyncMock(return_value=True)
+
+        service = FileWatcherService(mock_config, mock_event, library)
+        # No set_slicing_services call — should not raise
+        await service._apply_folder_rules(self._local_file(), is_new_file=True)
+
+
 class TestWatchFolderModelRules:
     """Test WatchFolder model rule fields (migration 038)."""
 

--- a/tests/services/test_file_watcher_service.py
+++ b/tests/services/test_file_watcher_service.py
@@ -21,8 +21,13 @@ class TestPrintFileHandler:
 
     def test_supported_extensions(self):
         """Test supported file extensions are defined."""
-        expected = {'.stl', '.3mf', '.gcode', '.obj', '.ply'}
+        expected = {'.stl', '.3mf', '.gcode', '.bgcode', '.obj', '.ply'}
         assert PrintFileHandler.SUPPORTED_EXTENSIONS == expected
+
+    def test_should_process_file_valid_bgcode(self):
+        """Test BGCODE files are processed."""
+        handler = PrintFileHandler(MagicMock())
+        assert handler.should_process_file("/path/to/model.bgcode") is True
 
     def test_should_process_file_valid_stl(self):
         """Test STL files are processed."""
@@ -630,6 +635,268 @@ class TestFileWatcherServiceScan:
 
             # Should only find root file
             assert len(service._local_files) == 1
+
+
+class TestFileWatcherServiceStability:
+    """Test write-stability handling and thread-safe scheduling."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_file_stable_returns_true_for_finished_file(self):
+        """Test stability check passes for a file that is not changing."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+        service.STABILITY_CHECK_INTERVAL = 0.05
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "stable.stl"
+            test_file.write_bytes(b"content")
+
+            assert await service._wait_for_file_stable(test_file) is True
+
+    @pytest.mark.asyncio
+    async def test_wait_for_file_stable_returns_false_for_missing_file(self):
+        """Test stability check fails for a nonexistent file."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+        service.STABILITY_CHECK_INTERVAL = 0.05
+
+        assert await service._wait_for_file_stable(Path("/nonexistent/file.stl")) is False
+
+    @pytest.mark.asyncio
+    async def test_wait_for_file_stable_waits_for_write_to_finish(self):
+        """Test stability check keeps waiting while the file grows."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+        service.STABILITY_CHECK_INTERVAL = 0.1
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "growing.stl"
+            test_file.write_bytes(b"start")
+
+            async def keep_writing():
+                for i in range(3):
+                    await asyncio.sleep(0.03)
+                    with open(test_file, 'ab') as f:
+                        f.write(b"more data")
+
+            writer = asyncio.create_task(keep_writing())
+            result = await service._wait_for_file_stable(test_file)
+            await writer
+
+            assert result is True
+            # The full content must have been present when stability was declared
+            assert test_file.stat().st_size == len(b"start") + 3 * len(b"more data")
+
+    @pytest.mark.asyncio
+    async def test_handle_file_created_in_flight_guard(self):
+        """Test concurrent created events for the same path process once."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+        service.STABILITY_CHECK_INTERVAL = 0.05
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            service._watched_folders[tmpdir] = {
+                'watch': None,
+                'path': Path(tmpdir),
+                'recursive': True
+            }
+            test_file = Path(tmpdir) / "test.stl"
+            test_file.write_bytes(b"test content")
+
+            with patch.object(service, '_process_discovered_file',
+                              new_callable=AsyncMock) as mock_process:
+                await asyncio.gather(
+                    service._handle_file_created(str(test_file)),
+                    service._handle_file_created(str(test_file)),
+                    service._handle_file_created(str(test_file)),
+                )
+
+                assert mock_process.call_count == 1
+
+    def test_schedule_from_thread_without_loop_drops_coroutine(self):
+        """Test scheduling from a foreign thread with no captured loop drops safely."""
+        import threading as _threading
+
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+        service._loop = None
+
+        async def dummy():
+            pass
+
+        errors = []
+
+        def run_in_thread():
+            try:
+                service._schedule_from_thread(dummy())
+            except Exception as e:
+                errors.append(e)
+
+        thread = _threading.Thread(target=run_in_thread)
+        thread.start()
+        thread.join()
+
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_schedule_from_thread_bridges_to_loop(self):
+        """Test a coroutine scheduled from a foreign thread runs on the loop."""
+        import threading as _threading
+
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+        service._loop = asyncio.get_running_loop()
+
+        ran = asyncio.Event()
+
+        async def marker():
+            ran.set()
+
+        thread = _threading.Thread(
+            target=lambda: service._schedule_from_thread(marker())
+        )
+        thread.start()
+        thread.join()
+
+        await asyncio.wait_for(ran.wait(), timeout=2.0)
+
+
+class TestFileWatcherServiceStableIds:
+    """Test deterministic file IDs."""
+
+    def test_make_file_id_deterministic(self):
+        """Test the same path always yields the same ID."""
+        id1 = FileWatcherService._make_file_id("/watch/model.stl")
+        id2 = FileWatcherService._make_file_id("/watch/model.stl")
+        assert id1 == id2
+        assert id1.startswith("local_")
+
+    def test_make_file_id_differs_per_path(self):
+        """Test different paths yield different IDs."""
+        id1 = FileWatcherService._make_file_id("/watch/a.stl")
+        id2 = FileWatcherService._make_file_id("/watch/b.stl")
+        assert id1 != id2
+
+
+class TestFileWatcherServiceRescan:
+    """Test on-demand folder rescan."""
+
+    @pytest.mark.asyncio
+    async def test_rescan_folder_unknown_folder_raises(self):
+        """Test rescanning an unwatched folder raises ValueError."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+
+        with pytest.raises(ValueError):
+            await service.rescan_folder("/not/watched")
+
+    @pytest.mark.asyncio
+    async def test_rescan_folder_finds_new_files(self):
+        """Test rescan discovers files added after the initial scan."""
+        mock_config = MagicMock()
+        mock_config.watch_folder_db = None
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+
+        service = FileWatcherService(mock_config, mock_event)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            service._watched_folders[tmpdir] = {
+                'watch': None,
+                'path': Path(tmpdir),
+                'recursive': True
+            }
+
+            (Path(tmpdir) / "first.stl").write_bytes(b"one")
+            await service._scan_folder(Path(tmpdir), recursive=True)
+
+            (Path(tmpdir) / "second.stl").write_bytes(b"two")
+            result = await service.rescan_folder(tmpdir)
+
+            assert result['files_found'] == 2
+            assert result['new_files'] == 1
+            assert len(service._local_files) == 2
+
+
+class TestFileWatcherServiceLibraryReconciliation:
+    """Test that deletes/moves are reconciled with the library."""
+
+    @pytest.mark.asyncio
+    async def test_handle_file_deleted_removes_library_source(self):
+        """Test deleting a watched original removes its watch_folder source."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+
+        mock_library = MagicMock()
+        mock_library.enabled = True
+        mock_library.remove_file_source = AsyncMock()
+
+        service = FileWatcherService(mock_config, mock_event, mock_library)
+
+        local_file = LocalFile(
+            file_id="local_123",
+            filename="test.stl",
+            file_path="/watch/test.stl",
+            file_size=1024,
+            file_type=".stl",
+            modified_time=datetime.now(),
+            watch_folder_path="/watch",
+            relative_path="test.stl",
+            checksum="abc123"
+        )
+        service._local_files["local_123"] = local_file
+
+        await service._handle_file_deleted("/watch/test.stl")
+
+        assert "local_123" not in service._local_files
+        mock_library.remove_file_source.assert_awaited_once_with(
+            "abc123", "watch_folder", "/watch"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_file_deleted_without_checksum_skips_library(self):
+        """Test deletion of a file with unknown checksum touches no library."""
+        mock_config = MagicMock()
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+
+        mock_library = MagicMock()
+        mock_library.enabled = True
+        mock_library.remove_file_source = AsyncMock()
+
+        service = FileWatcherService(mock_config, mock_event, mock_library)
+
+        local_file = LocalFile(
+            file_id="local_123",
+            filename="test.stl",
+            file_path="/watch/test.stl",
+            file_size=1024,
+            file_type=".stl",
+            modified_time=datetime.now(),
+            watch_folder_path="/watch",
+            relative_path="test.stl"
+        )
+        service._local_files["local_123"] = local_file
+
+        await service._handle_file_deleted("/watch/test.stl")
+
+        mock_library.remove_file_source.assert_not_awaited()
 
 
 class TestFileWatcherServiceLibraryIntegration:

--- a/tests/services/test_file_watcher_service.py
+++ b/tests/services/test_file_watcher_service.py
@@ -899,6 +899,153 @@ class TestFileWatcherServiceLibraryReconciliation:
         mock_library.remove_file_source.assert_not_awaited()
 
 
+class TestFileWatcherServiceFolderRules:
+    """Test per-folder processing rules (Phase 7b)."""
+
+    def _make_service(self, folder, library=None):
+        from unittest.mock import MagicMock
+        mock_config = MagicMock()
+        mock_config.watch_folder_db.get_watch_folder_by_path = AsyncMock(return_value=folder)
+        mock_event = MagicMock()
+        mock_event.emit_event = AsyncMock()
+        if library is None:
+            library = MagicMock()
+            library.enabled = True
+            library.assign_tag_by_name = AsyncMock(return_value=True)
+        return FileWatcherService(mock_config, mock_event, library), library
+
+    def _local_file(self, relative_path="vases/spiral.stl", checksum="abc123"):
+        return LocalFile(
+            file_id="local_1",
+            filename=Path(relative_path).name,
+            file_path=f"/watch/{relative_path}",
+            file_size=100,
+            file_type=".stl",
+            modified_time=datetime.now(),
+            watch_folder_path="/watch",
+            relative_path=relative_path,
+            checksum=checksum
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_tag_uses_first_level_subfolder(self):
+        """Test auto_tag tags with the first-level subfolder name."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_tag=True)
+
+        service, library = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file("vases/nested/spiral.stl"))
+
+        library.assign_tag_by_name.assert_awaited_once_with("abc123", "vases")
+
+    @pytest.mark.asyncio
+    async def test_auto_tag_skips_root_level_files(self):
+        """Test files directly in the watch folder get no subfolder tag."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_tag=True)
+
+        service, library = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file("spiral.stl"))
+
+        library.assign_tag_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_classification_tag_applied(self):
+        """Test business classification is applied as a tag."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", classification="business")
+
+        service, library = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file("spiral.stl"))
+
+        library.assign_tag_by_name.assert_awaited_once_with("abc123", "business")
+
+    @pytest.mark.asyncio
+    async def test_auto_tag_and_classification_combined(self):
+        """Test both rules apply together."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_tag=True, classification="private")
+
+        service, library = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file("vases/spiral.stl"))
+
+        assert library.assign_tag_by_name.await_count == 2
+        tags = [call.args[1] for call in library.assign_tag_by_name.await_args_list]
+        assert tags == ["vases", "private"]
+
+    @pytest.mark.asyncio
+    async def test_no_rules_no_tags(self):
+        """Test a folder without rules applies nothing."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch")
+
+        service, library = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file("vases/spiral.stl"))
+
+        library.assign_tag_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_folder_is_ignored(self):
+        """Test a file whose folder has no DB record applies nothing."""
+        service, library = self._make_service(None)
+        await service._apply_folder_rules(self._local_file("vases/spiral.stl"))
+
+        library.assign_tag_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_checksum_skips_rules(self):
+        """Test rules require a library checksum."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_tag=True)
+
+        service, library = self._make_service(folder)
+        await service._apply_folder_rules(self._local_file("vases/spiral.stl", checksum=None))
+
+        library.assign_tag_by_name.assert_not_awaited()
+
+
+class TestWatchFolderModelRules:
+    """Test WatchFolder model rule fields (migration 038)."""
+
+    def test_from_db_row_pre_migration_defaults(self):
+        """Test rows without rule columns get safe defaults."""
+        from src.models.watch_folder import WatchFolder
+        row = (1, "/watch", 1, 1, None, None, 0, None, 1, None, None,
+               "manual", None, None)
+
+        folder = WatchFolder.from_db_row(row)
+
+        assert folder.auto_tag is False
+        assert folder.classification is None
+        assert folder.default_printer_id is None
+        assert folder.default_profile_id is None
+
+    def test_from_db_row_with_rule_columns(self):
+        """Test rows with rule columns parse them."""
+        from src.models.watch_folder import WatchFolder
+        row = (1, "/watch", 1, 1, None, None, 0, None, 1, None, None,
+               "manual", None, None, 1, "business", "printer_1", "profile_2")
+
+        folder = WatchFolder.from_db_row(row)
+
+        assert folder.auto_tag is True
+        assert folder.classification == "business"
+        assert folder.default_printer_id == "printer_1"
+        assert folder.default_profile_id == "profile_2"
+
+    def test_to_dict_includes_rules(self):
+        """Test to_dict exposes rule fields."""
+        from src.models.watch_folder import WatchFolder
+        folder = WatchFolder(folder_path="/watch", auto_tag=True, classification="private")
+
+        data = folder.to_dict()
+
+        assert data['auto_tag'] is True
+        assert data['classification'] == "private"
+        assert 'default_printer_id' in data
+        assert 'default_profile_id' in data
+
+
 class TestFileWatcherServiceLibraryIntegration:
     """Test library service integration."""
 


### PR DESCRIPTION
- dependency-security-scan.yml: add a "Close resolved vulnerability
  issue" step so a clean scheduled scan closes the open security alert
  (previously the workflow only ever opened/updated it, so issue #346
  would stay open forever after the vulnerabilities were fixed).
- docs/MASTERPLAN.md: refresh from the stale v2.26.0/Jan snapshot to
  v2.41.7 — document the Slicer Integration epic, Model Generator,
  Orders Tracking, Usage Statistics Phase 3, Multi-Theme and Tools
  pages; add a "Next Candidates" list; correct the branch strategy to
  the current feature-branch-to-master model.